### PR TITLE
Fix “No JSON object could be decoded” issue

### DIFF
--- a/CodeNewRoman-NF.json
+++ b/CodeNewRoman-NF.json
@@ -1,4 +1,4 @@
-﻿{
+{
     "version":  "",
     "license":  "MIT",
     "homepage":  "https://github.com/ryanoasis/nerd-fonts",


### PR DESCRIPTION
Python’s json library chokes on parsing this file and Gohu-NF.json with the error “No JSON object could be decoded”