### PR TITLE
fix(installer): Use $_.FullName to work with PowerShell 5 and 6

### DIFF
--- a/bin/generate-manifests.ps1
+++ b/bin/generate-manifests.ps1
@@ -15,7 +15,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install `$app'\"; exit 1 }",
             "Get-ChildItem `$dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name `$_.Name.Replace(`$_.Extension, ' (TrueType)') -Value `$_.Name -Force | Out-Null",
-            "    Copy-Item \"`$dir\\`$_\" -destination \"`$env:windir\\Fonts\"",
+            "    Copy-Item `$_.FullName -destination \"`$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/3270-NF.json
+++ b/bucket/3270-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/AnonymousPro-NF.json
+++ b/bucket/AnonymousPro-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/Arimo-NF.json
+++ b/bucket/Arimo-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/AurulentSansMono-NF.json
+++ b/bucket/AurulentSansMono-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/BigBlueTerminal-NF.json
+++ b/bucket/BigBlueTerminal-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/BitstreamVeraSansMono-NF.json
+++ b/bucket/BitstreamVeraSansMono-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/Bold-NF.json
+++ b/bucket/Bold-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/BoldItalic-NF.json
+++ b/bucket/BoldItalic-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/CodeNewRoman-NF.json
+++ b/bucket/CodeNewRoman-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/Cousine-NF.json
+++ b/bucket/Cousine-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/DejaVuSansMono-NF.json
+++ b/bucket/DejaVuSansMono-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/DroidSansMono-NF.json
+++ b/bucket/DroidSansMono-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/FantasqueSansMono-NF.json
+++ b/bucket/FantasqueSansMono-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/FiraCode-NF.json
+++ b/bucket/FiraCode-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/FiraMono-NF.json
+++ b/bucket/FiraMono-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/Go-Mono-NF.json
+++ b/bucket/Go-Mono-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/Gohu-NF.json
+++ b/bucket/Gohu-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/Hack-NF.json
+++ b/bucket/Hack-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/Hasklig-NF.json
+++ b/bucket/Hasklig-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/HeavyData-NF.json
+++ b/bucket/HeavyData-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/Hermit-NF.json
+++ b/bucket/Hermit-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/Inconsolata-NF.json
+++ b/bucket/Inconsolata-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/InconsolataGo-NF.json
+++ b/bucket/InconsolataGo-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/InconsolataLGC-NF.json
+++ b/bucket/InconsolataLGC-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/Iosevka-NF.json
+++ b/bucket/Iosevka-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/Italic-NF.json
+++ b/bucket/Italic-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/Lekton-NF.json
+++ b/bucket/Lekton-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/LiberationMono-NF.json
+++ b/bucket/LiberationMono-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/MPlus-NF.json
+++ b/bucket/MPlus-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/Meslo-NF.json
+++ b/bucket/Meslo-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/Monofur-NF.json
+++ b/bucket/Monofur-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/Monoid-NF.json
+++ b/bucket/Monoid-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/Mononoki-NF.json
+++ b/bucket/Mononoki-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/Noto-NF.json
+++ b/bucket/Noto-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/OpenDyslexic-NF.json
+++ b/bucket/OpenDyslexic-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/Overpass-NF.json
+++ b/bucket/Overpass-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/ProFont-NF.json
+++ b/bucket/ProFont-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/ProggyClean-NF.json
+++ b/bucket/ProggyClean-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/Regular-NF.json
+++ b/bucket/Regular-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/RobotoMono-NF.json
+++ b/bucket/RobotoMono-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/SarasaGothic-ttc.json
+++ b/bucket/SarasaGothic-ttc.json
@@ -12,7 +12,7 @@
         "script": [
             "Get-ChildItem $dir -filter 'sarasa*.ttc' | ForEach-Object {",
             "  New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "  Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "  Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/SarasaGothic.json
+++ b/bucket/SarasaGothic.json
@@ -12,7 +12,7 @@
         "script": [
             "Get-ChildItem $dir -filter 'sarasa*.ttf' | ForEach-Object {",
             "  New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "  Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "  Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/ShareTechMono-NF.json
+++ b/bucket/ShareTechMono-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/SourceCodePro-NF.json
+++ b/bucket/SourceCodePro-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/SpaceMono-NF.json
+++ b/bucket/SpaceMono-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/Terminus-NF.json
+++ b/bucket/Terminus-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/Tinos-NF.json
+++ b/bucket/Tinos-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/Ubuntu-NF.json
+++ b/bucket/Ubuntu-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },

--- a/bucket/UbuntuMono-NF.json
+++ b/bucket/UbuntuMono-NF.json
@@ -14,7 +14,7 @@
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
             "Get-ChildItem $dir -filter '*Windows Compatible.*' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
-            "    Copy-Item \"$dir\\$_\" -destination \"$env:windir\\Fonts\"",
+            "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
         ]
     },


### PR DESCRIPTION
This fixes a problem with PowerShell 6 handling the result from `Get-ChildItem` differently than PowerShell 5.
Closes #12