### PR TITLE
Add Source Han & Noto CJK Mega/Ultra OTCs

### DIFF
--- a/bucket/Noto-CJK-Mega-OTC.json
+++ b/bucket/Noto-CJK-Mega-OTC.json
@@ -1,0 +1,34 @@
+{
+    "version": "20190603",
+    "license": "OFL-1.1",
+    "homepage": "https://github.com/adobe-fonts/source-han-super-otc",
+    "url": "https://github.com/adobe-fonts/source-han-super-otc/releases/download/20190603/NotoCJK.ttc",
+    "hash": "md5:5fb3f42574c27390bc60347858f4bf8e",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/adobe-fonts/source-han-super-otc/releases/download/$version/NotoCJK.ttc",
+        "hash": {
+            "url": "https://github.com/adobe-fonts/source-han-super-otc",
+            "find": "href=\"#noto-cjknotocjkttc\">.+?MD5 hash is ([A-Fa-f0-9]{32})"
+        }
+    },
+    "installer": {
+        "script": [
+            "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
+            "Get-ChildItem $dir -filter '*.ttc' | ForEach-Object {",
+            "  New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
+            "  Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
+            "}"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop uninstall $app'\"; exit 1 }",
+            "Get-ChildItem $dir -filter '*.ttc' | ForEach-Object {",
+            "  Remove-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Force -ErrorAction SilentlyContinue",
+            "  Remove-Item \"$env:windir\\Fonts\\$($_.Name)\" -Force -ErrorAction SilentlyContinue",
+            "}",
+            "Write-Host \"The Noto CJK Mega OTC (OpenType Collection) has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta"
+        ]
+    }
+}

--- a/bucket/Source-Han-Mega-OTC.json
+++ b/bucket/Source-Han-Mega-OTC.json
@@ -1,0 +1,34 @@
+{
+    "version": "20190603",
+    "license": "OFL-1.1",
+    "homepage": "https://github.com/adobe-fonts/source-han-super-otc",
+    "url": "https://github.com/adobe-fonts/source-han-super-otc/releases/download/20190603/SourceHan.ttc",
+    "hash": "md5:8f12d2fff6492b917496a3718e60cd5b",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/adobe-fonts/source-han-super-otc/releases/download/$version/SourceHan.ttc",
+        "hash": {
+            "url": "https://github.com/adobe-fonts/source-han-super-otc",
+            "find": "href=\"#source-hansourcehanttc\">.+?MD5 hash is ([A-Fa-f0-9]{32})"
+        }
+    },
+    "installer": {
+        "script": [
+            "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
+            "Get-ChildItem $dir -filter '*.ttc' | ForEach-Object {",
+            "  New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
+            "  Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
+            "}"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop uninstall $app'\"; exit 1 }",
+            "Get-ChildItem $dir -filter '*.ttc' | ForEach-Object {",
+            "  Remove-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Force -ErrorAction SilentlyContinue",
+            "  Remove-Item \"$env:windir\\Fonts\\$($_.Name)\" -Force -ErrorAction SilentlyContinue",
+            "}",
+            "Write-Host \"The Source Han Mega OTC (OpenType Collection) has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta"
+        ]
+    }
+}

--- a/bucket/Source-Han-Noto-CJK-Ultra-OTC.json
+++ b/bucket/Source-Han-Noto-CJK-Ultra-OTC.json
@@ -1,0 +1,34 @@
+{
+    "version": "20190603",
+    "license": "OFL-1.1",
+    "homepage": "https://github.com/adobe-fonts/source-han-super-otc",
+    "url": "https://github.com/adobe-fonts/source-han-super-otc/releases/download/20190603/SourceHanNotoCJK.ttc",
+    "hash": "md5:d50619f15a3c4130bc26380bfe8bca52",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/adobe-fonts/source-han-super-otc/releases/download/$version/SourceHanNotoCJK.ttc",
+        "hash": {
+            "url": "https://github.com/adobe-fonts/source-han-super-otc",
+            "find": "href=\"#source-han--noto-cjksourcehannotocjkttc\">.+?MD5 hash is ([A-Fa-f0-9]{32})"
+        }
+    },
+    "installer": {
+        "script": [
+            "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
+            "Get-ChildItem $dir -filter '*.ttc' | ForEach-Object {",
+            "  New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
+            "  Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
+            "}"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop uninstall $app'\"; exit 1 }",
+            "Get-ChildItem $dir -filter '*.ttc' | ForEach-Object {",
+            "  Remove-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Force -ErrorAction SilentlyContinue",
+            "  Remove-Item \"$env:windir\\Fonts\\$($_.Name)\" -Force -ErrorAction SilentlyContinue",
+            "}",
+            "Write-Host \"The Source Han & Noto CJK Ultra OTC (OpenType Collection) has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta"
+        ]
+    }
+}


### PR DESCRIPTION
https://github.com/adobe-fonts/source-han-super-otc

https://blogs.adobe.com/CCJKType/2017/08/super-mega-ultra-otcs.html

> Anyway, a single-style/family OTC that combines all of its fonts is called a **Super OTC**. When multiple styles of the same family, such as Source Han Sans (36 fonts), Source Han Serif (28 fonts), and the Japanese-only Source Han Code JP (14 fonts), are combined into a single *OpenType Collection*, it is called a **Mega OTC**, and its name is therefore Source Han Mega OTC (78 fonts). By extension, the Noto CJK Mega OTC (64 fonts) includes Noto Sans CJK (36 fonts) and Noto Serif CJK (28 fonts).
> 
> We can take this to the next level, which is to combine the Source Han Mega OTC and Noto CJK Mega OTC into an even larger OpenType Collection with 142 fonts, called Source Han & Noto CJK **Ultra OTC**.