### PR TITLE
Add 8 CJK Fonts

### DIFF
--- a/bucket/Hanamin.json
+++ b/bucket/Hanamin.json
@@ -1,0 +1,35 @@
+{
+    "homepage": "https://osdn.net/projects/hanazono-font/",
+    "description": "Free CJK serif font including over 80,000 Unicode characters.",
+    "version": "20170904",
+    "license": "OFL-1.1",
+    "url": "http://dl.osdn.jp/hanazono-font/68253/hanazono-20170904.zip",
+    "hash": "571cd4a09ae7da0c642d640fc2442c050aa450ebb0587a95cdd097d41a9c9572",
+    "installer": {
+        "script": [
+            "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
+            "Get-ChildItem $dir -filter '*.ttf' | ForEach-Object {",
+            "  New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
+            "  Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
+            "}"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop uninstall $app'\"; exit 1 }",
+            "Get-ChildItem $dir -filter '*.ttf' | ForEach-Object {",
+            "  Remove-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Force -ErrorAction SilentlyContinue",
+            "  Remove-Item \"$env:windir\\Fonts\\$($_.Name)\" -Force -ErrorAction SilentlyContinue",
+            "}",
+            "Write-Host \"Font 'HanaMin' has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta"
+        ]
+    },
+    "checkver": {
+        "url": "https://osdn.net/projects/hanazono-font/",
+        "regex": "(?s)hanazono-font/releases/(?<tag>[\\d]+)\\\">hanazono-font.*?\\(([\\d]{4})-([\\d]{2})-([\\d]{2})\\)</a>",
+        "replace": "${1}${2}${3}"
+    },
+    "autoupdate": {
+        "url": "http://dl.osdn.jp/hanazono-font/$matchTag/hanazono-$version.zip"
+    }
+}

--- a/bucket/Rounded-L-Mplus.json
+++ b/bucket/Rounded-L-Mplus.json
@@ -1,0 +1,34 @@
+{
+    "homepage": "http://jikasei.me/font/rounded-mplus/about.html",
+    "description": "CJK font based on the Mplus font, but with more rounded shape. (less rounder version)",
+    "version": "20150529",
+    "license": {
+        "identifier": "Freeware",
+        "url": "http://jikasei.me/font/rounded-mplus/license.html"
+    },
+    "url": "https://ymu.dl.osdn.jp/users/8/8568/rounded-l-mplus-20150529.7z",
+    "hash": "44ebd9b9a18576374ef1c40c6c02a44ccab031e70f433b5547d4ae11bb6fe76a",
+    "installer": {
+        "script": [
+            "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
+            "Get-ChildItem $dir -filter '*.ttf' | ForEach-Object {",
+            "  New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
+            "  Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
+            "}"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop uninstall $app'\"; exit 1 }",
+            "Get-ChildItem $dir -filter '*.ttf' | ForEach-Object {",
+            "  Remove-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Force -ErrorAction SilentlyContinue",
+            "  Remove-Item \"$env:windir\\Fonts\\$($_.Name)\" -Force -ErrorAction SilentlyContinue",
+            "}",
+            "Write-Host \"Font 'Rounded-L M+' has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta"
+        ]
+    },
+    "checkver": "https://osdn.jp/downloads/users/8/(?<tag>\\d+)/rounded-l-mplus-(\\d{8}).7z",
+    "autoupdate": {
+        "url": "https://ymu.dl.osdn.jp/users/8/$matchTag/rounded-l-mplus-$version.7z"
+    }
+}

--- a/bucket/Rounded-Mplus.json
+++ b/bucket/Rounded-Mplus.json
@@ -1,0 +1,34 @@
+{
+    "homepage": "http://jikasei.me/font/rounded-mplus/about.html",
+    "description": "CJK font based on the Mplus font, but with more rounded shape.",
+    "version": "20150529",
+    "license": {
+        "identifier": "Freeware",
+        "url": "http://jikasei.me/font/rounded-mplus/license.html"
+    },
+    "url": "https://ymu.dl.osdn.jp/users/8/8569/rounded-mplus-20150529.7z",
+    "hash": "e746736c8ded99fe9a9dd72a241ec59435eaa282a18e7ac33a26dc0578c06ff7",
+    "installer": {
+        "script": [
+            "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
+            "Get-ChildItem $dir -filter '*.ttf' | ForEach-Object {",
+            "  New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
+            "  Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
+            "}"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop uninstall $app'\"; exit 1 }",
+            "Get-ChildItem $dir -filter '*.ttf' | ForEach-Object {",
+            "  Remove-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Force -ErrorAction SilentlyContinue",
+            "  Remove-Item \"$env:windir\\Fonts\\$($_.Name)\" -Force -ErrorAction SilentlyContinue",
+            "}",
+            "Write-Host \"Font 'Rounded M+' has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta"
+        ]
+    },
+    "checkver": "https://osdn.jp/downloads/users/8/(?<tag>\\d+)/rounded-mplus-(\\d{8}).7z",
+    "autoupdate": {
+        "url": "https://ymu.dl.osdn.jp/users/8/$matchTag/rounded-mplus-$version.7z"
+    }
+}

--- a/bucket/Rounded-X-Mplus.json
+++ b/bucket/Rounded-X-Mplus.json
@@ -1,0 +1,34 @@
+{
+    "homepage": "http://jikasei.me/font/rounded-mplus/about.html",
+    "description": "CJK font based on the Mplus font, but with more rounded shape. (extra round version)",
+    "version": "20150529",
+    "license": {
+        "identifier": "Freeware",
+        "url": "http://jikasei.me/font/rounded-mplus/license.html"
+    },
+    "url": "https://ymu.dl.osdn.jp/users/8/8570/rounded-x-mplus-20150529.7z",
+    "hash": "22a20428d953ded808ddf391868d1c0c3d3aae933a299e947e5094df525faf31",
+    "installer": {
+        "script": [
+            "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
+            "Get-ChildItem $dir -filter '*.ttf' | ForEach-Object {",
+            "  New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
+            "  Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
+            "}"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop uninstall $app'\"; exit 1 }",
+            "Get-ChildItem $dir -filter '*.ttf' | ForEach-Object {",
+            "  Remove-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Force -ErrorAction SilentlyContinue",
+            "  Remove-Item \"$env:windir\\Fonts\\$($_.Name)\" -Force -ErrorAction SilentlyContinue",
+            "}",
+            "Write-Host \"Font 'Rounded-X M+' has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta"
+        ]
+    },
+    "checkver": "https://osdn.jp/downloads/users/8/(?<tag>\\d+)/rounded-x-mplus-(\\d{8}).7z",
+    "autoupdate": {
+        "url": "https://ymu.dl.osdn.jp/users/8/$matchTag/rounded-x-mplus-$version.7z"
+    }
+}

--- a/bucket/Setofont.json
+++ b/bucket/Setofont.json
@@ -1,0 +1,31 @@
+{
+    "homepage": "https://osdn.net/projects/setofont/",
+    "description": "CJK hand-written font including over 80,000 Unicode characters.",
+    "version": "6.20",
+    "license": "OFL-1.1",
+    "url": "http://dl.osdn.jp/setofont/61995/setofont_v_6_20.zip",
+    "hash": "d940029f4cbe736fb6c556f6bd45170b26ca3db5dc198fb1663f9d6137b575db",
+    "installer": {
+        "script": [
+            "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
+            "Get-ChildItem $dir -filter 'setofont\\*.ttf' | ForEach-Object {",
+            "  New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
+            "  Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
+            "}"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop uninstall $app'\"; exit 1 }",
+            "Get-ChildItem $dir -filter 'setofont\\*.ttf' | ForEach-Object {",
+            "  Remove-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Force -ErrorAction SilentlyContinue",
+            "  Remove-Item \"$env:windir\\Fonts\\$($_.Name)\" -Force -ErrorAction SilentlyContinue",
+            "}",
+            "Write-Host \"Font 'HanaMin' has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta"
+        ]
+    },
+    "checkver": "setofont/releases/(?<tag>\\d+)\\\">setofont SetoFont v([\\d.]+)</a>",
+    "autoupdate": {
+        "url": "http://dl.osdn.jp/setofont/$matchTag/setofont_v_$majorVersion_$minorVersion.zip"
+    }
+}

--- a/bucket/Tanuki-Permanent-Marker.json
+++ b/bucket/Tanuki-Permanent-Marker.json
@@ -1,0 +1,37 @@
+{
+    "homepage": "http://tanukifont.com/tanuki-permanent-marker/",
+    "description": "CJK font that imitates the strokes of permanent marker pen.",
+    "version": "1.21",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://tanukifont.com/fonts-user-policy/"
+    },
+    "url": "https://tanukifont.com/download/TanukiMagic_1_21.zip",
+    "hash": "2e167e22c9cfa71d5ff3fdf8f69a1001021cc5118f5884d0179d4c144378ee67",
+    "installer": {
+        "script": [
+            "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
+            "Get-ChildItem $dir -filter '*.ttf' | ForEach-Object {",
+            "  New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
+            "  Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
+            "}"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop uninstall $app'\"; exit 1 }",
+            "Get-ChildItem $dir -filter '*.ttf' | ForEach-Object {",
+            "  Remove-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Force -ErrorAction SilentlyContinue",
+            "  Remove-Item \"$env:windir\\Fonts\\$($_.Name)\" -Force -ErrorAction SilentlyContinue",
+            "}",
+            "Write-Host \"Font 'Tanuki Permanent Marker' has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta"
+        ]
+    },
+    "checkver": {
+        "regex": "TanukiMagic_([\\d]+)_([\\d]+).zip",
+        "replace": "${1}.${2}"
+    },
+    "autoupdate": {
+        "url": "https://tanukifont.com/download/TanukiMagic_$majorVersion_$minorVersion.zip"
+    }
+}

--- a/bucket/Wenquanyi-Microhei.json
+++ b/bucket/Wenquanyi-Microhei.json
@@ -1,0 +1,34 @@
+{
+    "homepage": "http://wenq.org/",
+    "description": "CJK sans-serif font derived from Droid Sans.",
+    "version": "0.2.0-beta",
+    "license": "GPL-2.0-or-later",
+    "url": "https://dl.sourceforge.net/projects/wqy/files/wqy-microhei/0.2.0-beta/wqy-microhei-0.2.0-beta.tar.gz",
+    "hash": "sha1:28023041b22b6368bcfae076de68109b81e77976",
+    "installer": {
+        "script": [
+            "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
+            "Get-ChildItem $dir -filter 'wqy-microhei\\*.ttc' | ForEach-Object {",
+            "  New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
+            "  Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
+            "}"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop uninstall $app'\"; exit 1 }",
+            "Get-ChildItem $dir -filter 'wqy-microhei\\*.ttc' | ForEach-Object {",
+            "  Remove-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Force -ErrorAction SilentlyContinue",
+            "  Remove-Item \"$env:windir\\Fonts\\$($_.Name)\" -Force -ErrorAction SilentlyContinue",
+            "}",
+            "Write-Host \"Font 'WenQuanYi Microhei' has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta"
+        ]
+    },
+    "checkver": {
+        "url": "https://sourceforge.net/projects/wqy/files/wqy-microhei/",
+        "regex": "<tr title=\\\"([\\w.-]+)\\\""
+    },
+    "autoupdate": {
+        "url": "https://dl.sourceforge.net/projects/wqy/files/wqy-microhei/$version/wqy-microhei-$version.tar.gz"
+    }
+}

--- a/bucket/Wenquanyi-Zenhei.json
+++ b/bucket/Wenquanyi-Zenhei.json
@@ -1,0 +1,34 @@
+{
+    "homepage": "http://wenq.org/",
+    "description": "CJK sans-serif font that focuses on on-screen readibility.",
+    "version": "0.9.45",
+    "license": "GPL-2.0-or-later",
+    "url": "https://dl.sourceforge.net/projects/wqy/files/wqy-zenhei/0.9.45 (Fighting-state RC1)/wqy-zenhei-0.9.45.tar.gz",
+    "hash": "sha1:b86b65d3048ade868fcc89229cfac6baf80a3e54",
+    "installer": {
+        "script": [
+            "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
+            "Get-ChildItem $dir -filter 'wqy-zenhei\\*.ttc' | ForEach-Object {",
+            "  New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
+            "  Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
+            "}"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop uninstall $app'\"; exit 1 }",
+            "Get-ChildItem $dir -filter 'wqy-zenhei\\*.ttc' | ForEach-Object {",
+            "  Remove-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Force -ErrorAction SilentlyContinue",
+            "  Remove-Item \"$env:windir\\Fonts\\$($_.Name)\" -Force -ErrorAction SilentlyContinue",
+            "}",
+            "Write-Host \"Font 'WenQuanYi Zenhei' has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta"
+        ]
+    },
+    "checkver": {
+        "url": "https://sourceforge.net/projects/wqy/files/wqy-zenhei/",
+        "regex": "<tr title=\\\"([\\d.]+)(?<suffix>.*?)\\\""
+    },
+    "autoupdate": {
+        "url": "https://dl.sourceforge.net/projects/wqy/files/wqy-zenhei/$version$matchSuffix/wqy-zenhei-$version.tar.gz"
+    }
+}


### PR DESCRIPTION
* Adding 8 CJK (Chinese-Japanese-Korean) Fonts
    * **HanaMin** (花園明朝体) ([link](https://osdn.net/projects/hanazono-font/)) -- traditional serif printing font.
    * **WenQuanYi Zhenhei** (文泉驿正黑) and **Microhei**(文泉驿微米黑) ([link](http://wenq.org)) -- serif font dedicated for on-screen display.
    * **Tanuki Permanent Marker** (たぬき油性マジック) ([link](http://tanukifont.com/tanuki-permanent-marker/)) -- hand-written marker style font
    * **SetoFont** (瀬戸フォント) ([link](https://osdn.net/projects/setofont/)) -- cute hand-written font
    * **Rounded M+** ([link](http://jikasei.me/font/rounded-mplus/about.html)), Rounded-L M+ (less rounded version), and Rounded-X M+ (more rounded version). -- sans-serif font derived from the M+ font.

* All these fonts have a large character set, which can support most of the characters from **Simplified Chinese, Traditional Chinese, Japanese and Korean**

* The install/uninstall scripts are copied from the `Source-Han-Mega-OTC` package.

* WenQuanYi Zhenhei is pronounced **Zhenghei** in Chinese, but I will keep the name *Zhenhei* since it is the official name for the font.

Please let me know if there are any problems. Thanks.