### PR TITLE
Setofont: Fix typo in the prompt message

### DIFF
--- a/bucket/Setofont.json
+++ b/bucket/Setofont.json
@@ -21,7 +21,7 @@
             "  Remove-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Force -ErrorAction SilentlyContinue",
             "  Remove-Item \"$env:windir\\Fonts\\$($_.Name)\" -Force -ErrorAction SilentlyContinue",
             "}",
-            "Write-Host \"Font 'HanaMin' has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta"
+            "Write-Host \"Font 'Seto Font' has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta"
         ]
     },
     "checkver": "setofont/releases/(?<tag>\\d+)\\\">setofont SetoFont v([\\d.]+)</a>",


### PR DESCRIPTION
I forgot to change the font name in the prompt message for `uninstaller`. Sorry about that.