### PR TITLE
Add region-specific SarasaGothic font packages

### DIFF
--- a/bucket/SarasaGothic-CL.json
+++ b/bucket/SarasaGothic-CL.json
@@ -1,0 +1,32 @@
+{
+    "##": "Renaming .7z to .7z_ so that the archive will not be automatically extracted by Scoop.",
+    "version": "0.10.0",
+    "license": "OFL-1.1",
+    "homepage": "https://github.com/be5invis/Sarasa-Gothic",
+    "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v0.10.0/sarasa-gothic-ttf-0.10.0.7z#/dl.7z_",
+    "hash": "ec0cf4a0d6b1b7a0d8bbb7835733361f96dce0f53e2b34ba526c18b700859f6c",
+    "depands": "7zip",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v$version/sarasa-gothic-ttf-$version.7z#/dl.7z_"
+    },
+    "installer": {
+        "script": [
+            "Invoke-ExternalCommand 7z -ArgumentList('e', \"$dir\\dl.7z_\" ,\"-o$dir\", '*-cl-*.ttf') | Out-Null",
+            "Remove-Item \"$dir\\dl.7z_\"",
+            "Get-ChildItem $dir -filter 'sarasa*.ttf' | ForEach-Object {",
+            "  New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
+            "  Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
+            "}"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "Get-ChildItem $dir -filter 'sarasa*.ttf' | ForEach-Object {",
+            "  Remove-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Force -ErrorAction SilentlyContinue",
+            "  Remove-Item \"$env:windir\\Fonts\\$($_.Name)\" -Force -ErrorAction SilentlyContinue",
+            "}",
+            "Write-Host \"The 'Sarasa-Gothic' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta"
+        ]
+    }
+}

--- a/bucket/SarasaGothic-HK.json
+++ b/bucket/SarasaGothic-HK.json
@@ -1,0 +1,32 @@
+{
+    "##": "Renaming .7z to .7z_ so that the archive will not be automatically extracted by Scoop.",
+    "version": "0.10.0",
+    "license": "OFL-1.1",
+    "homepage": "https://github.com/be5invis/Sarasa-Gothic",
+    "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v0.10.0/sarasa-gothic-ttf-0.10.0.7z#/dl.7z_",
+    "hash": "ec0cf4a0d6b1b7a0d8bbb7835733361f96dce0f53e2b34ba526c18b700859f6c",
+    "depands": "7zip",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v$version/sarasa-gothic-ttf-$version.7z#/dl.7z_"
+    },
+    "installer": {
+        "script": [
+            "Invoke-ExternalCommand 7z -ArgumentList('e', \"$dir\\dl.7z_\" ,\"-o$dir\", '*-hk-*.ttf') | Out-Null",
+            "Remove-Item \"$dir\\dl.7z_\"",
+            "Get-ChildItem $dir -filter 'sarasa*.ttf' | ForEach-Object {",
+            "  New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
+            "  Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
+            "}"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "Get-ChildItem $dir -filter 'sarasa*.ttf' | ForEach-Object {",
+            "  Remove-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Force -ErrorAction SilentlyContinue",
+            "  Remove-Item \"$env:windir\\Fonts\\$($_.Name)\" -Force -ErrorAction SilentlyContinue",
+            "}",
+            "Write-Host \"The 'Sarasa-Gothic' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta"
+        ]
+    }
+}

--- a/bucket/SarasaGothic-J.json
+++ b/bucket/SarasaGothic-J.json
@@ -1,0 +1,32 @@
+{
+    "##": "Renaming .7z to .7z_ so that the archive will not be automatically extracted by Scoop.",
+    "version": "0.10.0",
+    "license": "OFL-1.1",
+    "homepage": "https://github.com/be5invis/Sarasa-Gothic",
+    "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v0.10.0/sarasa-gothic-ttf-0.10.0.7z#/dl.7z_",
+    "hash": "ec0cf4a0d6b1b7a0d8bbb7835733361f96dce0f53e2b34ba526c18b700859f6c",
+    "depands": "7zip",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v$version/sarasa-gothic-ttf-$version.7z#/dl.7z_"
+    },
+    "installer": {
+        "script": [
+            "Invoke-ExternalCommand 7z -ArgumentList('e', \"$dir\\dl.7z_\" ,\"-o$dir\", '*-j-*.ttf') | Out-Null",
+            "Remove-Item \"$dir\\dl.7z_\"",
+            "Get-ChildItem $dir -filter 'sarasa*.ttf' | ForEach-Object {",
+            "  New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
+            "  Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
+            "}"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "Get-ChildItem $dir -filter 'sarasa*.ttf' | ForEach-Object {",
+            "  Remove-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Force -ErrorAction SilentlyContinue",
+            "  Remove-Item \"$env:windir\\Fonts\\$($_.Name)\" -Force -ErrorAction SilentlyContinue",
+            "}",
+            "Write-Host \"The 'Sarasa-Gothic' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta"
+        ]
+    }
+}

--- a/bucket/SarasaGothic-K.json
+++ b/bucket/SarasaGothic-K.json
@@ -1,0 +1,32 @@
+{
+    "##": "Renaming .7z to .7z_ so that the archive will not be automatically extracted by Scoop.",
+    "version": "0.10.0",
+    "license": "OFL-1.1",
+    "homepage": "https://github.com/be5invis/Sarasa-Gothic",
+    "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v0.10.0/sarasa-gothic-ttf-0.10.0.7z#/dl.7z_",
+    "hash": "ec0cf4a0d6b1b7a0d8bbb7835733361f96dce0f53e2b34ba526c18b700859f6c",
+    "depands": "7zip",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v$version/sarasa-gothic-ttf-$version.7z#/dl.7z_"
+    },
+    "installer": {
+        "script": [
+            "Invoke-ExternalCommand 7z -ArgumentList('e', \"$dir\\dl.7z_\" ,\"-o$dir\", '*-k-*.ttf') | Out-Null",
+            "Remove-Item \"$dir\\dl.7z_\"",
+            "Get-ChildItem $dir -filter 'sarasa*.ttf' | ForEach-Object {",
+            "  New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
+            "  Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
+            "}"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "Get-ChildItem $dir -filter 'sarasa*.ttf' | ForEach-Object {",
+            "  Remove-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Force -ErrorAction SilentlyContinue",
+            "  Remove-Item \"$env:windir\\Fonts\\$($_.Name)\" -Force -ErrorAction SilentlyContinue",
+            "}",
+            "Write-Host \"The 'Sarasa-Gothic' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta"
+        ]
+    }
+}

--- a/bucket/SarasaGothic-SC.json
+++ b/bucket/SarasaGothic-SC.json
@@ -1,0 +1,32 @@
+{
+    "##": "Renaming .7z to .7z_ so that the archive will not be automatically extracted by Scoop.",
+    "version": "0.10.0",
+    "license": "OFL-1.1",
+    "homepage": "https://github.com/be5invis/Sarasa-Gothic",
+    "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v0.10.0/sarasa-gothic-ttf-0.10.0.7z#/dl.7z_",
+    "hash": "ec0cf4a0d6b1b7a0d8bbb7835733361f96dce0f53e2b34ba526c18b700859f6c",
+    "depands": "7zip",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v$version/sarasa-gothic-ttf-$version.7z#/dl.7z_"
+    },
+    "installer": {
+        "script": [
+            "Invoke-ExternalCommand 7z -ArgumentList('e', \"$dir\\dl.7z_\" ,\"-o$dir\", '*-sc-*.ttf') | Out-Null",
+            "Remove-Item \"$dir\\dl.7z_\"",
+            "Get-ChildItem $dir -filter 'sarasa*.ttf' | ForEach-Object {",
+            "  New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
+            "  Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
+            "}"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "Get-ChildItem $dir -filter 'sarasa*.ttf' | ForEach-Object {",
+            "  Remove-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Force -ErrorAction SilentlyContinue",
+            "  Remove-Item \"$env:windir\\Fonts\\$($_.Name)\" -Force -ErrorAction SilentlyContinue",
+            "}",
+            "Write-Host \"The 'Sarasa-Gothic' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta"
+        ]
+    }
+}

--- a/bucket/SarasaGothic-TC.json
+++ b/bucket/SarasaGothic-TC.json
@@ -1,0 +1,32 @@
+{
+    "##": "Renaming .7z to .7z_ so that the archive will not be automatically extracted by Scoop.",
+    "version": "0.10.0",
+    "license": "OFL-1.1",
+    "homepage": "https://github.com/be5invis/Sarasa-Gothic",
+    "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v0.10.0/sarasa-gothic-ttf-0.10.0.7z#/dl.7z_",
+    "hash": "ec0cf4a0d6b1b7a0d8bbb7835733361f96dce0f53e2b34ba526c18b700859f6c",
+    "depands": "7zip",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v$version/sarasa-gothic-ttf-$version.7z#/dl.7z_"
+    },
+    "installer": {
+        "script": [
+            "Invoke-ExternalCommand 7z -ArgumentList('e', \"$dir\\dl.7z_\" ,\"-o$dir\", '*-tc-*.ttf') | Out-Null",
+            "Remove-Item \"$dir\\dl.7z_\"",
+            "Get-ChildItem $dir -filter 'sarasa*.ttf' | ForEach-Object {",
+            "  New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
+            "  Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
+            "}"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "Get-ChildItem $dir -filter 'sarasa*.ttf' | ForEach-Object {",
+            "  Remove-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Force -ErrorAction SilentlyContinue",
+            "  Remove-Item \"$env:windir\\Fonts\\$($_.Name)\" -Force -ErrorAction SilentlyContinue",
+            "}",
+            "Write-Host \"The 'Sarasa-Gothic' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta"
+        ]
+    }
+}


### PR DESCRIPTION
This adds 6 individual Sarasa font packages (region-specific) using the same file as `SarasaGothic`. The difference is that these regional-specific packages only extracts **a part of the font family** instead of all of them.

* The original **SarasaGothic** package contains 6 different sets of SarasaGothic, which represents different regional standards for glyphs. (SC: China mainland, TC: Taiwan, HK: Hong Kong, J: Japan, K: Korea, CL: Classic/16th century China)

* There are only slight differences in pen strokes between those standards. The picture below shows the difference of glyphs from Taiwan, HK, China, Japan and Korea.

* Users only need one of those `SarasaGothic` to show all the supported glyphs. That is, if you only installed `SarasaGothic TC`(Taiwan), The font can still be applied on characters that only appears in Japanese. The only difference is that the pen strokes will be in Taiwanese style.

* Therefore, users will only need **one of the 6 regional sets**, except for some rare cases. Seperate them into 6 packages can avoid unnessarily long font list (of 6 regions * 6 styles* 4 font weights = **144 fonts!**).


(By the way, someone has [sent an issue](https://github.com/be5invis/Sarasa-Gothic/issues/99) about whether the fonts can be downloaded seperately, but the developer tend not to do that due to file size issues.)


![different standards](https://c2.staticflickr.com/6/5724/30406729503_72d5ce8493_o.png)