### PR TITLE
SarasaGothic fonts: fix typo

### DIFF
--- a/bucket/SarasaGothic-CL.json
+++ b/bucket/SarasaGothic-CL.json
@@ -5,7 +5,7 @@
     "homepage": "https://github.com/be5invis/Sarasa-Gothic",
     "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v0.10.0/sarasa-gothic-ttf-0.10.0.7z#/dl.7z_",
     "hash": "ec0cf4a0d6b1b7a0d8bbb7835733361f96dce0f53e2b34ba526c18b700859f6c",
-    "depands": "7zip",
+    "depends": "7zip",
     "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v$version/sarasa-gothic-ttf-$version.7z#/dl.7z_"

--- a/bucket/SarasaGothic-HK.json
+++ b/bucket/SarasaGothic-HK.json
@@ -5,7 +5,7 @@
     "homepage": "https://github.com/be5invis/Sarasa-Gothic",
     "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v0.10.0/sarasa-gothic-ttf-0.10.0.7z#/dl.7z_",
     "hash": "ec0cf4a0d6b1b7a0d8bbb7835733361f96dce0f53e2b34ba526c18b700859f6c",
-    "depands": "7zip",
+    "depends": "7zip",
     "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v$version/sarasa-gothic-ttf-$version.7z#/dl.7z_"

--- a/bucket/SarasaGothic-J.json
+++ b/bucket/SarasaGothic-J.json
@@ -5,7 +5,7 @@
     "homepage": "https://github.com/be5invis/Sarasa-Gothic",
     "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v0.10.0/sarasa-gothic-ttf-0.10.0.7z#/dl.7z_",
     "hash": "ec0cf4a0d6b1b7a0d8bbb7835733361f96dce0f53e2b34ba526c18b700859f6c",
-    "depands": "7zip",
+    "depends": "7zip",
     "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v$version/sarasa-gothic-ttf-$version.7z#/dl.7z_"

--- a/bucket/SarasaGothic-K.json
+++ b/bucket/SarasaGothic-K.json
@@ -5,7 +5,7 @@
     "homepage": "https://github.com/be5invis/Sarasa-Gothic",
     "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v0.10.0/sarasa-gothic-ttf-0.10.0.7z#/dl.7z_",
     "hash": "ec0cf4a0d6b1b7a0d8bbb7835733361f96dce0f53e2b34ba526c18b700859f6c",
-    "depands": "7zip",
+    "depends": "7zip",
     "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v$version/sarasa-gothic-ttf-$version.7z#/dl.7z_"

--- a/bucket/SarasaGothic-SC.json
+++ b/bucket/SarasaGothic-SC.json
@@ -5,7 +5,7 @@
     "homepage": "https://github.com/be5invis/Sarasa-Gothic",
     "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v0.10.0/sarasa-gothic-ttf-0.10.0.7z#/dl.7z_",
     "hash": "ec0cf4a0d6b1b7a0d8bbb7835733361f96dce0f53e2b34ba526c18b700859f6c",
-    "depands": "7zip",
+    "depends": "7zip",
     "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v$version/sarasa-gothic-ttf-$version.7z#/dl.7z_"

--- a/bucket/SarasaGothic-TC.json
+++ b/bucket/SarasaGothic-TC.json
@@ -5,7 +5,7 @@
     "homepage": "https://github.com/be5invis/Sarasa-Gothic",
     "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v0.10.0/sarasa-gothic-ttf-0.10.0.7z#/dl.7z_",
     "hash": "ec0cf4a0d6b1b7a0d8bbb7835733361f96dce0f53e2b34ba526c18b700859f6c",
-    "depands": "7zip",
+    "depends": "7zip",
     "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v$version/sarasa-gothic-ttf-$version.7z#/dl.7z_"


### PR DESCRIPTION
Sorry I was blind. :sweat:

I didn't realize there was a typo because `Scoop` just ignores the "depands" field (instead of showing some error).