### PR TITLE
remove sudo dependency

### DIFF
--- a/bucket/3270-NF.json
+++ b/bucket/3270-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.0.0/3270.zip",
     "hash": "d4b34b2d6c7cb758d8d6c7213a08a732a3759da123904e316df08e38d421641b",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/3270.zip"
     },

--- a/bucket/AnonymousPro-NF.json
+++ b/bucket/AnonymousPro-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.0.0/AnonymousPro.zip",
     "hash": "a5ff0e9d8564594fafc0f3698ecaf08b38f87d140550736038fab0bc2b57b018",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/AnonymousPro.zip"
     },

--- a/bucket/Arimo-NF.json
+++ b/bucket/Arimo-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.0.0/Arimo.zip",
     "hash": "5b23a4607604cfecc7a4551fab86df86acd49c5ce8dfb93d51d195e6b7f0a09e",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Arimo.zip"
     },

--- a/bucket/AurulentSansMono-NF.json
+++ b/bucket/AurulentSansMono-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.0.0/AurulentSansMono.zip",
     "hash": "916a4a74f895587578cb5b2d55c37e513a87a15ce65c394e99f9c95a04b60fba",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/AurulentSansMono.zip"
     },

--- a/bucket/BigBlueTerminal-NF.json
+++ b/bucket/BigBlueTerminal-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.0.0/BigBlueTerminal.zip",
     "hash": "669e2d031437e53c3718fde54f20e6dc445fa6619dee0a0070e060c77de89caf",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/BigBlueTerminal.zip"
     },

--- a/bucket/BitstreamVeraSansMono-NF.json
+++ b/bucket/BitstreamVeraSansMono-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.0.0/BitstreamVeraSansMono.zip",
     "hash": "285c7c08ee2d651cf1f0bdb8a83b787adcab2449ac09b04c23aa4ae17a50d84b",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/BitstreamVeraSansMono.zip"
     },

--- a/bucket/Bold-NF.json
+++ b/bucket/Bold-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.0.0/Bold.zip",
     "hash": "7558459e9edac50336232f23f0f99c5a1b4fd5b0c17071899c3281797e550159",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Bold.zip"
     },

--- a/bucket/BoldItalic-NF.json
+++ b/bucket/BoldItalic-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.0.0/BoldItalic.zip",
     "hash": "af8eea02bb74ecf75e9505bece321118900b74a537ac620ddc3846464307934f",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/BoldItalic.zip"
     },

--- a/bucket/Cascadia-Code.json
+++ b/bucket/Cascadia-Code.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/microsoft/cascadia-code/releases/download/v1911.21/Cascadia.ttf",
     "hash": "cf5b69933c568eac4231303a952ce57c1581dac10c6e73c70b763cf9ecaabed4",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/microsoft/cascadia-code/releases/download/v$version/Cascadia.ttf"
     },

--- a/bucket/Cascadia-Mono.json
+++ b/bucket/Cascadia-Mono.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/microsoft/cascadia-code/releases/download/v1911.21/CascadiaMono.ttf",
     "hash": "00dd551dd2a91377f48d4361f715494cf394c053eae7ee550ced5f0db3a9706e",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/microsoft/cascadia-code/releases/download/v$version/CascadiaMono.ttf"
     },

--- a/bucket/CodeNewRoman-NF.json
+++ b/bucket/CodeNewRoman-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v1.2.0/CodeNewRoman.zip",
     "hash": "b4302eafd46bb7ffa4a5e349d298e2cfd68a82c02c68e9d2235f4d4d383668a3",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/CodeNewRoman.zip"
     },

--- a/bucket/Cousine-NF.json
+++ b/bucket/Cousine-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.0.0/Cousine.zip",
     "hash": "dae2a0a363b03ef2adaf9cd341e9e5210b23daef7dea617bdf79c375ced50c4e",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Cousine.zip"
     },

--- a/bucket/DejaVuSansMono-NF.json
+++ b/bucket/DejaVuSansMono-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.0.0/DejaVuSansMono.zip",
     "hash": "0a3a0f67e94bb6fdeb08215eef67afe4b9e01cee3df509b05eb9a3c31f4eb31b",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/DejaVuSansMono.zip"
     },

--- a/bucket/Delugia-Nerd-Font-Complete.json
+++ b/bucket/Delugia-Nerd-Font-Complete.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/adam7/delugia-code/releases/download/v1911.21/Delugia.Nerd.Font.Complete.ttf",
     "hash": "B4C92DE38BCB22BEEC08FE7A825FCE5447692DDB64B38F6A7DEEB87822E1B27B",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/adam7/delugia-code/releases/download/v$version/Delugia.Nerd.Font.Complete.ttf"
     },

--- a/bucket/Delugia-Nerd-Font.json
+++ b/bucket/Delugia-Nerd-Font.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/adam7/delugia-code/releases/download/v1911.21/Delugia.Nerd.Font.ttf",
     "hash": "CBC9E65AFEBF4FED3780696B8A529E87CCDD97BFAE28A57AD87BD06DF355A7B7",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/adam7/delugia-code/releases/download/v$version/Delugia.Nerd.Font.ttf"
     },

--- a/bucket/DroidSansMono-NF.json
+++ b/bucket/DroidSansMono-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.0.0/DroidSansMono.zip",
     "hash": "b48ace2486e2503aa829adcb4d5814567d23e46a99af4a79b21c2c00bb13bfda",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/DroidSansMono.zip"
     },

--- a/bucket/FantasqueSansMono-NF.json
+++ b/bucket/FantasqueSansMono-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.0.0/FantasqueSansMono.zip",
     "hash": "7274bae9949a6f5100f6c5248c9b9649bd64ba3f9f1e9b9dd53a71f8fdd6d9c0",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/FantasqueSansMono.zip"
     },

--- a/bucket/FiraCode-NF.json
+++ b/bucket/FiraCode-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.0.0/FiraCode.zip",
     "hash": "09894d24bf3d61493dba052187a9200497135a4b885cb837bcb637ad2e62070f",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/FiraCode.zip"
     },

--- a/bucket/FiraMono-NF.json
+++ b/bucket/FiraMono-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.0.0/FiraMono.zip",
     "hash": "1eb587b0985d61a9323e0cc979ce16cf820013f0dd235c3a5df979029f6e6e34",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/FiraMono.zip"
     },

--- a/bucket/Go-Mono-NF.json
+++ b/bucket/Go-Mono-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.0.0/Go-Mono.zip",
     "hash": "b9de3b4bab110938fe2fb15a838d3c8f7a87607373076062574b73287e520fa3",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Go-Mono.zip"
     },

--- a/bucket/Gohu-NF.json
+++ b/bucket/Gohu-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v1.2.0/Gohu.zip",
     "hash": "3c2cc94365093054b7b32638dfa1cba0ea09e02a8abd28395612de4c03fd1f4b",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Gohu.zip"
     },

--- a/bucket/Hack-NF.json
+++ b/bucket/Hack-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.0.0/Hack.zip",
     "hash": "d1147483fd0310fa6bfce6799f47654e3f435010fdc709877b15a23f090ed41c",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Hack.zip"
     },

--- a/bucket/Hasklig-NF.json
+++ b/bucket/Hasklig-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.0.0/Hasklig.zip",
     "hash": "1fd1d88f2ec48424654888e4c7afad7a423e4229f40b09be323dbf4a04600dbd",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Hasklig.zip"
     },

--- a/bucket/HeavyData-NF.json
+++ b/bucket/HeavyData-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.0.0/HeavyData.zip",
     "hash": "f39181014c5b65a9aa0a850fa0d4de94f7ebf406fa8c6dad8f5aadb3d74c98d8",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/HeavyData.zip"
     },

--- a/bucket/Hermit-NF.json
+++ b/bucket/Hermit-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.0.0/Hermit.zip",
     "hash": "5c656e844dfaf14355e5e607c738dabc903e1985a375bb907f1a200956774a18",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Hermit.zip"
     },

--- a/bucket/Inconsolata-NF.json
+++ b/bucket/Inconsolata-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.0.0/Inconsolata.zip",
     "hash": "7ef196ce9fa7b4bc3f9e0290a0de0fbefee123a705ba84a1993d6336a92a5164",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Inconsolata.zip"
     },

--- a/bucket/InconsolataGo-NF.json
+++ b/bucket/InconsolataGo-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.0.0/InconsolataGo.zip",
     "hash": "4a3860cb82de6e5e00dc13871269073a0367ccb75bc8d0f5d33d303e7d1e4986",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/InconsolataGo.zip"
     },

--- a/bucket/InconsolataLGC-NF.json
+++ b/bucket/InconsolataLGC-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.0.0/InconsolataLGC.zip",
     "hash": "e764c3fc484088dd12d93688f4be8efa7e89b8e87ff5be2e9473ab2f37a60c40",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/InconsolataLGC.zip"
     },

--- a/bucket/Iosevka-NF.json
+++ b/bucket/Iosevka-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.0.0/Iosevka.zip",
     "hash": "a67d9e2d66146e7f38ef0d19cda5d7f81cb769ea1e6716b545b30412ae8823a0",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Iosevka.zip"
     },

--- a/bucket/Italic-NF.json
+++ b/bucket/Italic-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.0.0/Italic.zip",
     "hash": "b4f7b6c6680009e84626ce87908038fee322d68085697a5e45254275ffbc73c3",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Italic.zip"
     },

--- a/bucket/Lekton-NF.json
+++ b/bucket/Lekton-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.0.0/Lekton.zip",
     "hash": "07ef874e46462524c53c1923ffc98aa53f7c2544303e326f218edd101f775ea0",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Lekton.zip"
     },

--- a/bucket/LiberationMono-NF.json
+++ b/bucket/LiberationMono-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.0.0/LiberationMono.zip",
     "hash": "c4c705a351483ce096d4ebb2af2a45364d193b295cb870cfe0f38e8b3a7ac136",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/LiberationMono.zip"
     },

--- a/bucket/MPlus-NF.json
+++ b/bucket/MPlus-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.0.0/MPlus.zip",
     "hash": "dc3aa81b0274d5feb36e86c68c79e25c44cbafee1b1a10dcc01acedb45a0403e",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/MPlus.zip"
     },

--- a/bucket/Meslo-NF.json
+++ b/bucket/Meslo-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.0.0/Meslo.zip",
     "hash": "350ff0b1061ca0d1e933c59861d6421ebb2667d494875fcb1821d3df44f08476",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Meslo.zip"
     },

--- a/bucket/Monofur-NF.json
+++ b/bucket/Monofur-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.0.0/Monofur.zip",
     "hash": "16b5cc275bd5689d3f3b348119c7356d9c1de67c46dd2d24f752972ad086b765",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Monofur.zip"
     },

--- a/bucket/Monoid-NF.json
+++ b/bucket/Monoid-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.0.0/Monoid.zip",
     "hash": "ad63efadd67364f2e20eb1d0c387927dd0d638899036a70b4a06ae7842178d48",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Monoid.zip"
     },

--- a/bucket/Mononoki-NF.json
+++ b/bucket/Mononoki-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.0.0/Mononoki.zip",
     "hash": "715813f9bdeddfa35a39681dedf4a61cf1b6cfe8e06b9b3ca19c391cb308a589",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Mononoki.zip"
     },

--- a/bucket/Noto-NF.json
+++ b/bucket/Noto-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.0.0/Noto.zip",
     "hash": "47598f6b3f7a21c27cb46510f14fe6b3490f1d636799a75dae23a2250db0cadd",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Noto.zip"
     },

--- a/bucket/OpenDyslexic-NF.json
+++ b/bucket/OpenDyslexic-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.0.0/OpenDyslexic.zip",
     "hash": "bcb29a9b70d2efda42b60962c55cdb4f0311fed10d314c68fd257529cc7f8709",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/OpenDyslexic.zip"
     },

--- a/bucket/Overpass-NF.json
+++ b/bucket/Overpass-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.0.0/Overpass.zip",
     "hash": "eeabe6120133bcc9af4cce452bb4bdaad5ea0ef5ecaaa6fef16f5c1b04c3280c",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Overpass.zip"
     },

--- a/bucket/ProFont-NF.json
+++ b/bucket/ProFont-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.0.0/ProFont.zip",
     "hash": "a82de4b5d5322bbe21ba3aed4520d7f2f3da72280a4caf005fb3d2787b36d325",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/ProFont.zip"
     },

--- a/bucket/ProggyClean-NF.json
+++ b/bucket/ProggyClean-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.0.0/ProggyClean.zip",
     "hash": "cf98665e543bc47bf669baaecd573b9ba35184b21c69bbe6e04450c7fb3ffbf2",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/ProggyClean.zip"
     },

--- a/bucket/Regular-NF.json
+++ b/bucket/Regular-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.0.0/Regular.zip",
     "hash": "05b107e935826c0e95dee55fe5c5c751b0d3d93ab0a5a333f9dd51fc170bda34",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Regular.zip"
     },

--- a/bucket/RobotoMono-NF.json
+++ b/bucket/RobotoMono-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.0.0/RobotoMono.zip",
     "hash": "0714a974b22bfedbed8855ef589a12f9c60167788278965bd61d3d5d06bcf8e8",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/RobotoMono.zip"
     },

--- a/bucket/ShareTechMono-NF.json
+++ b/bucket/ShareTechMono-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.0.0/ShareTechMono.zip",
     "hash": "0d697cf592e46d6c36e017a84e58a05343e3b4c2ea71e40671de3930c1582b9f",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/ShareTechMono.zip"
     },

--- a/bucket/SourceCodePro-NF.json
+++ b/bucket/SourceCodePro-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.0.0/SourceCodePro.zip",
     "hash": "f8e0cc0aceefa97a2c3f256fbc9a460038059ef0a193f02960f644daddfdfbbb",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/SourceCodePro.zip"
     },

--- a/bucket/SpaceMono-NF.json
+++ b/bucket/SpaceMono-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.0.0/SpaceMono.zip",
     "hash": "c41c8b4d9a634a8662aaa70d4541a534e82a13fbcc40c14149a01cda32925648",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/SpaceMono.zip"
     },

--- a/bucket/Terminus-NF.json
+++ b/bucket/Terminus-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.0.0/Terminus.zip",
     "hash": "3dd17846e4749415ab2ff06e6af254cfde627feda202cda14efc93e87adc4e9b",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Terminus.zip"
     },

--- a/bucket/Tinos-NF.json
+++ b/bucket/Tinos-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.0.0/Tinos.zip",
     "hash": "cfe1306602e7839f0898bf237ffa2cf1f5d686ea74d3619c39cf417ce2942426",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Tinos.zip"
     },

--- a/bucket/Ubuntu-NF.json
+++ b/bucket/Ubuntu-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.0.0/Ubuntu.zip",
     "hash": "1c63e03728d89bbc6df6d357d156b5adb1c90bde247933c7cb429e6482ad22bb",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Ubuntu.zip"
     },

--- a/bucket/UbuntuMono-NF.json
+++ b/bucket/UbuntuMono-NF.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.0.0/UbuntuMono.zip",
     "hash": "23b9fb5e683ae7ca81306a0c1da842a4d4cabb8bbec28ed5a7d604de688b2b8e",
     "checkver": "github",
-    "depends": "sudo",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/UbuntuMono.zip"
     },


### PR DESCRIPTION
Hi because `sudo` does not work in powershell core atm, I suggest removing the dependency.

Perhaps `Admin rights are required, please run 'sudo scoop install $app` should be adapted.

If you check 
https://github.com/matthewjberger/scoop-nerd-fonts/blob/a9386cab71f411977173f7b7382b6958dd84b31c/bucket/JetBrains-Mono.json it does not have a dependency on sudo