### PR TITLE
fix installation of JetBrains Mono fonts

### DIFF
--- a/bucket/JetBrains-Mono.json
+++ b/bucket/JetBrains-Mono.json
@@ -1,9 +1,9 @@
 {
     "version": "1.0.2",
     "description": "JetBrains Mono. A typeface for developers_",
-    "homepage": "https://www.jetbrains.com/lp/mono/",
+    "homepage": "https://github.com/JetBrains/JetBrainsMono",
     "license": "Apache-2.0",
-    "url": "https://download.jetbrains.com/fonts/JetBrainsMono-1.0.2.zip",
+    "url": "https://github.com/JetBrains/JetBrainsMono/releases/download/v1.0.2/JetBrainsMono-1.0.2.zip",
     "hash": "59f9b9762d5625eb438eedf034dbbcdcf09ed18ded994540b466872840229762",
     "installer": {
         "script": [
@@ -24,8 +24,8 @@
             "Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta"
         ]
     },
-    "checkver": "/fonts/JetBrainsMono-([\\d.]+)\\.zip",
+    "checkver": "github",
     "autoupdate": {
-        "url": "https://download.jetbrains.com/fonts/JetBrainsMono-$version.zip"
+        "url": "https://github.com/JetBrains/JetBrainsMono/releases/download/v$version/JetBrainsMono-$version.zip"
     }
 }

--- a/bucket/JetBrains-Mono.json
+++ b/bucket/JetBrains-Mono.json
@@ -1,7 +1,7 @@
 {
     "version": "1.0.2",
     "description": "JetBrains Mono. A typeface for developers_",
-    "homepage": "https://github.com/JetBrains/JetBrainsMono",
+    "homepage": "https://www.jetbrains.com/lp/mono/",
     "license": "Apache-2.0",
     "url": "https://github.com/JetBrains/JetBrainsMono/releases/download/v1.0.2/JetBrainsMono-1.0.2.zip",
     "hash": "59f9b9762d5625eb438eedf034dbbcdcf09ed18ded994540b466872840229762",
@@ -24,7 +24,9 @@
             "Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta"
         ]
     },
-    "checkver": "github",
+    "checkver": {
+        "github": "https://github.com/JetBrains/JetBrainsMono"
+    },
     "autoupdate": {
         "url": "https://github.com/JetBrains/JetBrainsMono/releases/download/v$version/JetBrainsMono-$version.zip"
     }

--- a/bucket/JetBrains-Mono.json
+++ b/bucket/JetBrains-Mono.json
@@ -8,7 +8,7 @@
     "installer": {
         "script": [
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
-            "Get-ChildItem $dir -filter '*.ttf' | ForEach-Object {",
+            "Get-ChildItem -recurse $dir -filter '*.ttf' | ForEach-Object {",
             "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
             "    Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
             "}"
@@ -17,7 +17,7 @@
     "uninstaller": {
         "script": [
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop uninstall $app'\"; exit 1 }",
-            "Get-ChildItem $dir -filter '*.ttf' | ForEach-Object {",
+            "Get-ChildItem -recurse $dir -filter '*.ttf' | ForEach-Object {",
             "    Remove-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Force -ErrorAction SilentlyContinue",
             "    Remove-Item \"$env:windir\\Fonts\\$($_.Name)\" -Force -ErrorAction SilentlyContinue",
             "}",


### PR DESCRIPTION
The files had changed location.

Use GitHub for auto update as it can find the latest version

This is after unzipping and listing their content
```
~\Downloads ❯ (Get-ChildItem .\JetBrainsMono-1.0.0\ -Recurse -Include *.ttf).FullName
C:\Users\josep\Downloads\JetBrainsMono-1.0.0\JetBrainsMono-Bold.ttf
C:\Users\josep\Downloads\JetBrainsMono-1.0.0\JetBrainsMono-Bold-Italic.ttf
C:\Users\josep\Downloads\JetBrainsMono-1.0.0\JetBrainsMono-ExtraBold.ttf
C:\Users\josep\Downloads\JetBrainsMono-1.0.0\JetBrainsMono-ExtraBold-Italic.ttf
C:\Users\josep\Downloads\JetBrainsMono-1.0.0\JetBrainsMono-Italic.ttf
C:\Users\josep\Downloads\JetBrainsMono-1.0.0\JetBrainsMono-Medium.ttf
C:\Users\josep\Downloads\JetBrainsMono-1.0.0\JetBrainsMono-Medium-Italic.ttf
C:\Users\josep\Downloads\JetBrainsMono-1.0.0\JetBrainsMono-Regular.ttf

~\Downloads ❯ (Get-ChildItem .\JetBrainsMono-1.0.2\ -Recurse -Include *.ttf).FullName
C:\Users\josep\Downloads\JetBrainsMono-1.0.2\ttf\JetBrainsMono-Bold.ttf
C:\Users\josep\Downloads\JetBrainsMono-1.0.2\ttf\JetBrainsMono-Bold-Italic.ttf
C:\Users\josep\Downloads\JetBrainsMono-1.0.2\ttf\JetBrainsMono-ExtraBold.ttf
C:\Users\josep\Downloads\JetBrainsMono-1.0.2\ttf\JetBrainsMono-ExtraBold-Italic.ttf
C:\Users\josep\Downloads\JetBrainsMono-1.0.2\ttf\JetBrainsMono-Italic.ttf
C:\Users\josep\Downloads\JetBrainsMono-1.0.2\ttf\JetBrainsMono-Medium.ttf
C:\Users\josep\Downloads\JetBrainsMono-1.0.2\ttf\JetBrainsMono-Medium-Italic.ttf
C:\Users\josep\Downloads\JetBrainsMono-1.0.2\ttf\JetBrainsMono-Regular.ttf
```