### PR TITLE
Update Fira Code To Version 3.1

### DIFF
--- a/bucket/FiraCode.json
+++ b/bucket/FiraCode.json
@@ -1,9 +1,9 @@
 {
-    "version": "2",
+    "version": "3.1",
     "license": "OFL-1.1",
     "homepage": "https://github.com/tonsky/FiraCode",
-    "url": "https://github.com/tonsky/FiraCode/releases/download/2/FiraCode_2.zip",
-    "hash": "60D5B1106B708CC134C521AAE4E503BB1D2EC3C9BF8AD978F2C659820505D492",
+    "url": "https://github.com/tonsky/FiraCode/releases/download/3.1/FiraCode_3.1.zip",
+    "hash": "CBCABD2C412EE4C3FEC4688BE8387DE18A33BB77BC5C5988E9FD9293A0B9DBB7",
     "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/tonsky/FiraCode/releases/download/$version/FiraCode_$version.zip"


### PR DESCRIPTION
Updates the Fira Code font to the latest version ([3.1](https://github.com/tonsky/FiraCode/releases/tag/3.1))