### PR TITLE
Update Fira Code To Version 4

### DIFF
--- a/bucket/FiraCode.json
+++ b/bucket/FiraCode.json
@@ -1,12 +1,12 @@
 {
-    "version": "3.1",
+    "version": "4",
     "license": "OFL-1.1",
     "homepage": "https://github.com/tonsky/FiraCode",
-    "url": "https://github.com/tonsky/FiraCode/releases/download/3.1/FiraCode_3.1.zip",
-    "hash": "CBCABD2C412EE4C3FEC4688BE8387DE18A33BB77BC5C5988E9FD9293A0B9DBB7",
+    "url": "https://github.com/tonsky/FiraCode/releases/download/4/Fira_Code_v4.zip",
+    "hash": "46ed45d1a793a56e13d31ed10fb7e09f5277731953a0d9522915644fc59086d8",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/tonsky/FiraCode/releases/download/$version/FiraCode_$version.zip"
+        "url": "https://github.com/tonsky/FiraCode/releases/download/$version/Fira_Code_v$version.zip"
     },
     "installer": {
         "script": [


### PR DESCRIPTION
Updates the Fira Code font to the latest version ([4](https://github.com/tonsky/FiraCode/releases/tag/4))

The naming of the .zip file changed (from `FiraCode_X.zip` to `Fira_Code_vX.zip`)
 so I had to change the download link in the .json file for the HASH check and for the download ofc.

Autoupdate passed:
![image](https://user-images.githubusercontent.com/32489486/82200058-d15efd80-98fe-11ea-9f44-e16fae81cf7d.png)
