### PR TITLE
Update CodeNewRoman-NF and Gohu-NF To Version 2.1.0

### DIFF
--- a/bucket/CodeNewRoman-NF.json
+++ b/bucket/CodeNewRoman-NF.json
@@ -1,9 +1,9 @@
 {
-    "version": "1.2.0",
+    "version": "2.1.0",
     "license": "MIT",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
-    "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v1.2.0/CodeNewRoman.zip",
-    "hash": "b4302eafd46bb7ffa4a5e349d298e2cfd68a82c02c68e9d2235f4d4d383668a3",
+    "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.1.0/CodeNewRoman.zip",
+    "hash": "ea0a58e9559e07f805aa48805b589d3adef81cfd10f0e481ef8aae3b2457fdd5",
     "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/CodeNewRoman.zip"

--- a/bucket/Gohu-NF.json
+++ b/bucket/Gohu-NF.json
@@ -1,9 +1,9 @@
 {
-    "version": "1.2.0",
+    "version": "2.1.0",
     "license": "MIT",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
-    "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v1.2.0/Gohu.zip",
-    "hash": "3c2cc94365093054b7b32638dfa1cba0ea09e02a8abd28395612de4c03fd1f4b",
+    "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.1.0/Gohu.zip",
+    "hash": "41f4f0c6960fc9f5ec332150c8143e20511363afcc2aa293d1e1dbf464be93e6",
     "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Gohu.zip"


### PR DESCRIPTION
This PR contains two commits to update:

- CodeNewRoman-NF
- Gohu-NF

to version [2.1.0](https://github.com/ryanoasis/nerd-fonts/releases/tag/v2.1.0).