### PR TITLE
FiraCode: Update To Version 5

### DIFF
--- a/bucket/FiraCode.json
+++ b/bucket/FiraCode.json
@@ -1,9 +1,9 @@
 {
-    "version": "4",
+    "version": "5",
     "license": "OFL-1.1",
     "homepage": "https://github.com/tonsky/FiraCode",
-    "url": "https://github.com/tonsky/FiraCode/releases/download/4/Fira_Code_v4.zip",
-    "hash": "46ed45d1a793a56e13d31ed10fb7e09f5277731953a0d9522915644fc59086d8",
+    "url": "https://github.com/tonsky/FiraCode/releases/download/5/Fira_Code_v5.zip",
+    "hash": "a095333b5e24d57f6536efb62d5425d3325243808dca410c6755d0cf7c5bd8da",
     "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/tonsky/FiraCode/releases/download/$version/Fira_Code_v$version.zip"


### PR DESCRIPTION
 Updates the FiraCode font to the latest version ([5](https://github.com/tonsky/FiraCode/releases/tag/5))

Autoupdate passed:
![image](https://user-images.githubusercontent.com/32489486/84053570-67dc8700-a9b2-11ea-851b-18519c1cea95.png)
