### PR TITLE
Bump sarasa's version to 0.31.2

### DIFF
--- a/bucket/SarasaGothic-CL.json
+++ b/bucket/SarasaGothic-CL.json
@@ -1,9 +1,9 @@
 {
     "##": "Renaming .7z to .7z_ so that the archive will not be automatically extracted by Scoop.",
-    "version": "0.30.2",
+    "version": "0.31.2",
     "license": "OFL-1.1",
     "homepage": "https://github.com/be5invis/Sarasa-Gothic",
-    "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v0.30.2/sarasa-gothic-ttf-0.31.2.7z#/dl.7z_",
+    "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v0.31.2/sarasa-gothic-ttf-0.31.2.7z#/dl.7z_",
     "hash": "867281850dccfd14fbd02524eee944e0304d52bd273b556f7dc804625386e2a0",
     "checkver": "github",
     "autoupdate": {

--- a/bucket/SarasaGothic-HK.json
+++ b/bucket/SarasaGothic-HK.json
@@ -1,9 +1,9 @@
 {
     "##": "Renaming .7z to .7z_ so that the archive will not be automatically extracted by Scoop.",
-    "version": "0.30.2",
+    "version": "0.31.2",
     "license": "OFL-1.1",
     "homepage": "https://github.com/be5invis/Sarasa-Gothic",
-    "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v0.30.2/sarasa-gothic-ttf-0.31.2.7z#/dl.7z_",
+    "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v0.31.2/sarasa-gothic-ttf-0.31.2.7z#/dl.7z_",
     "hash": "867281850dccfd14fbd02524eee944e0304d52bd273b556f7dc804625386e2a0",
     "checkver": "github",
     "autoupdate": {

--- a/bucket/SarasaGothic-J.json
+++ b/bucket/SarasaGothic-J.json
@@ -1,9 +1,9 @@
 {
     "##": "Renaming .7z to .7z_ so that the archive will not be automatically extracted by Scoop.",
-    "version": "0.30.2",
+    "version": "0.31.2",
     "license": "OFL-1.1",
     "homepage": "https://github.com/be5invis/Sarasa-Gothic",
-    "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v0.30.2/sarasa-gothic-ttf-0.31.2.7z#/dl.7z_",
+    "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v0.31.2/sarasa-gothic-ttf-0.31.2.7z#/dl.7z_",
     "hash": "867281850dccfd14fbd02524eee944e0304d52bd273b556f7dc804625386e2a0",
     "checkver": "github",
     "autoupdate": {

--- a/bucket/SarasaGothic-K.json
+++ b/bucket/SarasaGothic-K.json
@@ -1,9 +1,9 @@
 {
     "##": "Renaming .7z to .7z_ so that the archive will not be automatically extracted by Scoop.",
-    "version": "0.30.2",
+    "version": "0.31.2",
     "license": "OFL-1.1",
     "homepage": "https://github.com/be5invis/Sarasa-Gothic",
-    "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v0.30.2/sarasa-gothic-ttf-0.31.2.7z#/dl.7z_",
+    "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v0.31.2/sarasa-gothic-ttf-0.31.2.7z#/dl.7z_",
     "hash": "867281850dccfd14fbd02524eee944e0304d52bd273b556f7dc804625386e2a0",
     "checkver": "github",
     "autoupdate": {

--- a/bucket/SarasaGothic-SC.json
+++ b/bucket/SarasaGothic-SC.json
@@ -1,9 +1,9 @@
 {
     "##": "Renaming .7z to .7z_ so that the archive will not be automatically extracted by Scoop.",
-    "version": "0.30.2",
+    "version": "0.31.2",
     "license": "OFL-1.1",
     "homepage": "https://github.com/be5invis/Sarasa-Gothic",
-    "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v0.30.2/sarasa-gothic-ttf-0.31.2.7z#/dl.7z_",
+    "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v0.31.2/sarasa-gothic-ttf-0.31.2.7z#/dl.7z_",
     "hash": "867281850dccfd14fbd02524eee944e0304d52bd273b556f7dc804625386e2a0",
     "checkver": "github",
     "autoupdate": {

--- a/bucket/SarasaGothic-TC.json
+++ b/bucket/SarasaGothic-TC.json
@@ -1,9 +1,9 @@
 {
     "##": "Renaming .7z to .7z_ so that the archive will not be automatically extracted by Scoop.",
-    "version": "0.30.2",
+    "version": "0.31.2",
     "license": "OFL-1.1",
     "homepage": "https://github.com/be5invis/Sarasa-Gothic",
-    "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v0.30.2/sarasa-gothic-ttf-0.31.2.7z#/dl.7z_",
+    "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v0.31.2/sarasa-gothic-ttf-0.31.2.7z#/dl.7z_",
     "hash": "867281850dccfd14fbd02524eee944e0304d52bd273b556f7dc804625386e2a0",
     "checkver": "github",
     "autoupdate": {

--- a/bucket/SarasaGothic-ttc.json
+++ b/bucket/SarasaGothic-ttc.json
@@ -1,8 +1,8 @@
 {
-    "version": "0.30.2",
+    "version": "0.31.2",
     "license": "OFL-1.1",
     "homepage": "https://github.com/be5invis/Sarasa-Gothic",
-    "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v0.30.2/sarasa-gothic-ttc-0.30.2.7z",
+    "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v0.31.2/sarasa-gothic-ttc-0.31.2.7z",
     "hash": "44b14ab8ec5da43c7804c7d5e077de887bc889c1a1eca62765d46e0a0df36b99",
     "checkver": "github",
     "autoupdate": {

--- a/bucket/SarasaGothic.json
+++ b/bucket/SarasaGothic.json
@@ -1,8 +1,8 @@
 {
-    "version": "0.30.2",
+    "version": "0.31.2",
     "license": "OFL-1.1",
     "homepage": "https://github.com/be5invis/Sarasa-Gothic",
-    "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v0.30.2/sarasa-gothic-ttf-0.30.2.7z",
+    "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v0.31.2/sarasa-gothic-ttf-0.31.2.7z",
     "hash": "867281850dccfd14fbd02524eee944e0304d52bd273b556f7dc804625386e2a0",
     "checkver": "github",
     "autoupdate": {


### PR DESCRIPTION
Amendatory commit for [#108](https://github.com/matthewjberger/scoop-nerd-fonts/pull/108), bump versions and paths from `0.30.2` to `0.31.2`,   
excuse me for the first commit for scoop bucket.