### PR TITLE
update Source-Han-Sans to 2.004

### DIFF
--- a/bucket/Source-Han-Sans-HC.json
+++ b/bucket/Source-Han-Sans-HC.json
@@ -1,15 +1,15 @@
 {
-    "version": "2.003",
+    "version": "2.004",
     "license": "OFL-1.1",
     "homepage": "https://github.com/adobe-fonts/source-han-sans/",
-    "url": "https://github.com/adobe-fonts/source-han-sans/raw/release/OTF/SourceHanSansHC.zip",
-    "hash": "876bac859e6fcc0a6517756c8a29ba037e018fbe4ac8f358dc5e84e07541649e",
+    "url": "https://github.com/adobe-fonts/source-han-sans/releases/latest/download/SourceHanSansHC.zip",
+    "hash": "551cf3ad1527b3debe2b0efb94133c9ef75c873f75f11b933e6bd6a1f37a8a42",
     "checkver": {
-        "url": "https://github.com/adobe-fonts/source-han-sans/releases",
-        "regex": "source-han-sans/tree/([\\d.]+)R"
+        "url": "https://github.com/adobe-fonts/source-han-sans/releases/latest",
+        "regex": "Version ([\\d.]+)R"
     },
     "autoupdate": {
-        "url": "https://github.com/adobe-fonts/source-han-sans/raw/release/OTF/SourceHanSansHC.zip"
+        "url": "https://github.com/adobe-fonts/source-han-sans/releases/latest/download/SourceHanSansHC.zip"
     },
     "installer": {
         "script": [

--- a/bucket/Source-Han-Sans-J.json
+++ b/bucket/Source-Han-Sans-J.json
@@ -1,15 +1,15 @@
 {
-    "version": "2.003",
+    "version": "2.004",
     "license": "OFL-1.1",
     "homepage": "https://github.com/adobe-fonts/source-han-sans/",
-    "url": "https://github.com/adobe-fonts/source-han-sans/raw/release/OTF/SourceHanSansJ.zip",
-    "hash": "743b3ca4302a84f22408bedbf14595b2d61be92c73ab846a47dd007e46f02f19",
+    "url": "https://github.com/adobe-fonts/source-han-sans/releases/latest/download/SourceHanSansJ.zip",
+    "hash": "747734b49301784fed68440711a106de42714d3a7dbc79064a30bbb0cac3f986",
     "checkver": {
-        "url": "https://github.com/adobe-fonts/source-han-sans/releases",
-        "regex": "source-han-sans/tree/([\\d.]+)R"
+        "url": "https://github.com/adobe-fonts/source-han-sans/releases/latest",
+        "regex": "Version ([\\d.]+)R"
     },
     "autoupdate": {
-        "url": "https://github.com/adobe-fonts/source-han-sans/raw/release/OTF/SourceHanSansJ.zip"
+        "url": "https://github.com/adobe-fonts/source-han-sans/releases/latest/download/SourceHanSansJ.zip"
     },
     "installer": {
         "script": [

--- a/bucket/Source-Han-Sans-K.json
+++ b/bucket/Source-Han-Sans-K.json
@@ -1,15 +1,15 @@
 {
-    "version": "2.003",
+    "version": "2.004",
     "license": "OFL-1.1",
     "homepage": "https://github.com/adobe-fonts/source-han-sans/",
-    "url": "https://github.com/adobe-fonts/source-han-sans/raw/release/OTF/SourceHanSansK.zip",
-    "hash": "fad8bc448bd119b103817ae95156f9b4ac5cc0ab1e58c3ce7fbf240e8d5b5e67",
+    "url": "https://github.com/adobe-fonts/source-han-sans/releases/latest/download/SourceHanSansK.zip",
+    "hash": "5390443fb4fee71af369858d99d3fb78e67bf661194f91a776fb2b5713ab8f44",
     "checkver": {
-        "url": "https://github.com/adobe-fonts/source-han-sans/releases",
-        "regex": "source-han-sans/tree/([\\d.]+)R"
+        "url": "https://github.com/adobe-fonts/source-han-sans/releases/latest",
+        "regex": "Version ([\\d.]+)R"
     },
     "autoupdate": {
-        "url": "https://github.com/adobe-fonts/source-han-sans/raw/release/OTF/SourceHanSansK.zip"
+        "url": "https://github.com/adobe-fonts/source-han-sans/releases/latest/download/SourceHanSansK.zip"
     },
     "installer": {
         "script": [

--- a/bucket/Source-Han-Sans-SC.json
+++ b/bucket/Source-Han-Sans-SC.json
@@ -1,15 +1,15 @@
 {
-    "version": "2.003",
+    "version": "2.004",
     "license": "OFL-1.1",
     "homepage": "https://github.com/adobe-fonts/source-han-sans/",
-    "url": "https://github.com/adobe-fonts/source-han-sans/raw/release/OTF/SourceHanSansSC.zip",
-    "hash": "d23653e3a5ed75c49d86178277fd25ddbcd24226e829d5e0bdb3e63b171504c8",
+    "url": "https://github.com/adobe-fonts/source-han-sans/releases/latest/download/SourceHanSansSC.zip",
+    "hash": "2105cdb5a73a7d63fdfe8311312ad7f5c4d166e3c369a9cf737a35c90dee13a2",
     "checkver": {
-        "url": "https://github.com/adobe-fonts/source-han-sans/releases",
-        "regex": "source-han-sans/tree/([\\d.]+)R"
+        "url": "https://github.com/adobe-fonts/source-han-sans/releases/latest",
+        "regex": "Version ([\\d.]+)R"
     },
     "autoupdate": {
-        "url": "https://github.com/adobe-fonts/source-han-sans/raw/release/OTF/SourceHanSansSC.zip"
+        "url": "https://github.com/adobe-fonts/source-han-sans/releases/latest/download/SourceHanSansSC.zip"
     },
     "installer": {
         "script": [

--- a/bucket/Source-Han-Sans-TC.json
+++ b/bucket/Source-Han-Sans-TC.json
@@ -1,15 +1,15 @@
 {
-    "version": "2.003",
+    "version": "2.004",
     "license": "OFL-1.1",
     "homepage": "https://github.com/adobe-fonts/source-han-sans/",
-    "url": "https://github.com/adobe-fonts/source-han-sans/raw/release/OTF/SourceHanSansTC.zip",
-    "hash": "4ed489b7c2eb479be2af1240c9242c11bb2ed276b9850c99142352ac3659de6d",
+    "url": "https://github.com/adobe-fonts/source-han-sans/releases/latest/download/SourceHanSansTC.zip",
+    "hash": "e075d87d245c4a195e46d0f52fe050efc22e48c8f0f286863f77f03265bb7e9e",
     "checkver": {
-        "url": "https://github.com/adobe-fonts/source-han-sans/releases",
-        "regex": "source-han-sans/tree/([\\d.]+)R"
+        "url": "https://github.com/adobe-fonts/source-han-sans/releases/latest",
+        "regex": "Version ([\\d.]+)R"
     },
     "autoupdate": {
-        "url": "https://github.com/adobe-fonts/source-han-sans/raw/release/OTF/SourceHanSansTC.zip"
+        "url": "https://github.com/adobe-fonts/source-han-sans/releases/latest/download/SourceHanSansTC.zip"
     },
     "installer": {
         "script": [


### PR DESCRIPTION
update Source-Han-Sans to 2.004
now Source-Han-Sans do not put *.zip to repo, they put them in the release page.

- [x] Bug fix
- [x] check hash
- [x] rewrite the checkver regex
- [x] rewrite the autoupdate url 