### PR TITLE
Add Fira Code iScript

### DIFF
--- a/bucket/FiraCode-iScript.json
+++ b/bucket/FiraCode-iScript.json
@@ -1,0 +1,39 @@
+{
+    "version": "nightly",
+    "description": "A font mashup to be used in code editors. The Regular and Bold face styles are taken from Fira Code and Script12.",
+    "homepage": "https://github.com/kencrocken/FiraCodeiScript",
+    "license": "OFL-1.1",
+    "url": [
+        "https://github.com/kencrocken/FiraCodeiScript/raw/master/FiraCodeiScript-Bold.ttf",
+        "https://github.com/kencrocken/FiraCodeiScript/raw/master/FiraCodeiScript-Italic.ttf",
+        "https://github.com/kencrocken/FiraCodeiScript/raw/master/FiraCodeiScript-Regular.ttf"
+    ],
+    "installer": {
+        "script": [
+            "if (!(is_admin)) {",
+            "    error \"Administrator rights are required to install $app.\"",
+            "    exit 1",
+            "}",
+            "",
+            "Get-ChildItem $dir -filter '*.ttf' | ForEach-Object {",
+            "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
+            "    Copy-Item $_.FullName -destination \"$env:WINDIR\\Fonts\"",
+            "}"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "if (!(is_admin)) {",
+            "    error \"Administrator rights are required to install $app.\"",
+            "    exit 1",
+            "}",
+            "",
+            "Get-ChildItem $dir -filter '*.ttf' | ForEach-Object {",
+            "    Remove-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Force -ErrorAction SilentlyContinue",
+            "    Remove-Item \"$env:WINDIR\\Fonts\\$($_.Name)\" -Force -ErrorAction SilentlyContinue",
+            "}",
+            "",
+            "Write-Host \"Font 'Fira Code iScript' has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta"
+        ]
+    }
+}


### PR DESCRIPTION
close #96

[Fira Code iScript](https://github.com/kencrocken/FiraCodeiScript) is a font mashup to be used in code editors, displaying a script typeface for the italic font style. The Regular and Bold face styles are taken from [Fira Code](https://github.com/tonsky/FiraCode) and [Script12](https://www.myfontsfree.com/134618/script12pitchbt.htm).

Notes:
* **license** is marked as `OFL-1.1` according to **Fira Code** and **Script12** 's license.

![](https://user-images.githubusercontent.com/7041191/30752845-8c8484ce-9f8b-11e7-9df1-1d171b8d5e66.png)