### PR TITLE
jf-open-huninn: Add version 1.1

### DIFF
--- a/bucket/jf-open-huninn.json
+++ b/bucket/jf-open-huninn.json
@@ -1,0 +1,42 @@
+{
+    "version": "1.1",
+    "description": "CJK (Chinese-Japanese-Korean) sans-serif font with round curves. The name 'hunnin' means boba(tapioca balls).",
+    "homepage": "https://github.com/justfont/open-huninn-font",
+    "license": "OFL-1.1",
+    "url": "https://github.com/justfont/open-huninn-font/releases/download/v1.1/jf-openhuninn-1.1.zip",
+    "hash": "1b5a8d0204f5763408609d5e8182455d23a2ebc7450730aed19cc13c619bca37",
+    "extract_dir": "jf-openhuninn-1.1",
+    "installer": {
+        "script": [
+            "if (!(is_admin)) {",
+            "    error \"Administrator rights are required to install $app.\"",
+            "    exit 1",
+            "}",
+            "",
+            "Get-ChildItem $dir -filter '*.ttf' | ForEach-Object {",
+            "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
+            "    Copy-Item $_.FullName -destination \"$env:WINDIR\\Fonts\"",
+            "}"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "if (!(is_admin)) {",
+            "    error \"Administrator rights are required to install $app.\"",
+            "    exit 1",
+            "}",
+            "",
+            "Get-ChildItem $dir -filter '*.ttf' | ForEach-Object {",
+            "    Remove-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Force -ErrorAction SilentlyContinue",
+            "    Remove-Item \"$env:WINDIR\\Fonts\\$($_.Name)\" -Force -ErrorAction SilentlyContinue",
+            "}",
+            "",
+            "Write-Host \"Font 'jf-openhunnin' has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta"
+        ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/justfont/open-huninn-font/releases/download/v$version/jf-openhuninn-$version.zip",
+        "extract_dir": "jf-openhuninn-$version"
+    }
+}


### PR DESCRIPTION
**[JF Open Huninn](https://github.com/justfont/open-huninn-font)** is a CJK (Chinese-Japanese-Korean) sans-serif font with **round curves**.

It is released by [JustFont](https://justfont.com/), a commercial font foundry in Taiwan, but as an open-source fontface.

The name 'hunnin' means boba (tapioca balls).

Notes:
* The font is licensed with `OFL-1.1` according to [the developer's webpage](https://github.com/justfont/open-huninn-font/blob/master/license.txt).

![u2](https://user-images.githubusercontent.com/27724471/125150194-a2de5a80-e170-11eb-9913-2bfb8ef622e3.jpg)


