### PR TITLE
taipei-sans: Add version 1.000-beta

### DIFF
--- a/bucket/taipei-sans.json
+++ b/bucket/taipei-sans.json
@@ -1,0 +1,36 @@
+{
+    "version": "1.000-beta",
+    "description": "CJK (Chinese-Japanese-Korean) sans-serif font.",
+    "homepage": "https://sites.google.com/view/jtfoundry/en/ourproject",
+    "license": "OFL-1.1",
+    "url": "https://www.googleapis.com/drive/v3/files/1Zp-jKyTSM45NpBHRWlI6A5bQ7cRsGi1y?alt=media&key=AIzaSyAiaA0bWx34SyfTRvyl4UCCHwsCkvUBECc#/font.7z",
+    "hash": "5A58784EEEB1D9DD8955D8FCFC8A20BF668447ACB6836DBD9441E66AC5C3C2BF",
+    "installer": {
+        "script": [
+            "if (!(is_admin)) {",
+            "    error \"Administrator rights are required to install $app.\"",
+            "    exit 1",
+            "}",
+            "",
+            "Get-ChildItem $dir -filter '*.ttf' | ForEach-Object {",
+            "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
+            "    Copy-Item $_.FullName -destination \"$env:WINDIR\\Fonts\"",
+            "}"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "if (!(is_admin)) {",
+            "    error \"Administrator rights are required to install $app.\"",
+            "    exit 1",
+            "}",
+            "",
+            "Get-ChildItem $dir -filter '*.ttf' | ForEach-Object {",
+            "    Remove-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Force -ErrorAction SilentlyContinue",
+            "    Remove-Item \"$env:WINDIR\\Fonts\\$($_.Name)\" -Force -ErrorAction SilentlyContinue",
+            "}",
+            "",
+            "Write-Host \"Font 'Taipei Sans TC Beta' has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta"
+        ]
+    }
+}


### PR DESCRIPTION
**[Taipei Sans](https://sites.google.com/view/jtfoundry/en/ourproject)** is a sans-serif CJK (Chinese-Japanese-Korean) font.

Notes:
* The font is licensed with `OFL-1.1` according to [the developer's webpage](https://sites.google.com/view/jtfoundry/en/downloads?authuser=0).

![](https://free.com.tw/blog/wp-content/uploads/2019/07/taipei-sans-tc-5-reasons.png)