### PR TITLE
Soukou-Mincho: Add version 1.0

### DIFF
--- a/bucket/Soukou-Mincho.json
+++ b/bucket/Soukou-Mincho.json
@@ -1,0 +1,37 @@
+{
+    "version": "1.0",
+    "description": "Japanese and Traditinal Chinese font with sharp penstrokes. The name 'soukou' means armor.",
+    "homepage": "http://flopdesign.com/blog/font/5228/",
+    "license": "OFL-1.1",
+    "url": "https://www.flopdesign.com/images/datafont/flopdesign-op/SoukouMincho-Font.zip",
+    "hash": "9F81CE2891875C1F5353853F26AB6B1027470E154FB7B88DC52CE29B686E0897",
+    "extract_dir": "SoukouMincho-Font",
+    "installer": {
+        "script": [
+            "if (!(is_admin)) {",
+            "    error \"Administrator rights are required to install $app.\"",
+            "    exit 1",
+            "}",
+            "",
+            "Get-ChildItem $dir -filter '*.ttf' | ForEach-Object {",
+            "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
+            "    Copy-Item $_.FullName -destination \"$env:WINDIR\\Fonts\"",
+            "}"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "if (!(is_admin)) {",
+            "    error \"Administrator rights are required to install $app.\"",
+            "    exit 1",
+            "}",
+            "",
+            "Get-ChildItem $dir -filter '*.ttf' | ForEach-Object {",
+            "    Remove-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Force -ErrorAction SilentlyContinue",
+            "    Remove-Item \"$env:WINDIR\\Fonts\\$($_.Name)\" -Force -ErrorAction SilentlyContinue",
+            "}",
+            "",
+            "Write-Host \"Font 'SoukouMincho' has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta"
+        ]
+    }
+}

--- a/bucket/Soukou-Mincho.json
+++ b/bucket/Soukou-Mincho.json
@@ -1,6 +1,6 @@
 {
     "version": "1.0",
-    "description": "Japanese and Traditinal Chinese font with sharp penstrokes. The name 'soukou' means armor.",
+    "description": "Japanese and Traditional Chinese font with sharp penstrokes. The name 'soukou' means armor.",
     "homepage": "http://flopdesign.com/blog/font/5228/",
     "license": "OFL-1.1",
     "url": "https://www.flopdesign.com/images/datafont/flopdesign-op/SoukouMincho-Font.zip",


### PR DESCRIPTION
**[Soukou Mincho](http://flopdesign.com/blog/font/5228/) (装甲明朝)** is a **Japanese** and **Traditional Chinese** font with sharp penstrokes.

The name 'soukou' means armor.

Notes:
* The font is licensed as `OFL-1.1` according to [the developer's webpage](http://flopdesign.com/blog/font/5228/).

![u3](https://user-images.githubusercontent.com/27724471/125150936-00c17100-e176-11eb-84cd-d5db50995114.jpg)

![](https://www.flopdesign.com/blog/wp-content/uploads/2017/05/soukou-Mincho-font.png)

![](https://free.com.tw/blog/wp-content/uploads/2017/05/%E6%80%9D%E6%BA%90%E5%AE%8B%E9%AB%94%E4%BF%AE%E6%94%B9%E7%89%88%E3%80%8C%E8%A3%9D%E7%94%B2%E6%98%8E%E6%9C%9D%E3%80%8D%E5%AD%97%E5%9E%8B%E5%85%8D%E8%B2%BB%E4%B8%8B%E8%BC%892017-05-26_1329-1.png)