### PR TITLE
Tiresias: Add version 0.1

### DIFF
--- a/bucket/Tiresias.json
+++ b/bucket/Tiresias.json
@@ -1,0 +1,42 @@
+{
+    "version": "0.1",
+    "description": "Typeface degined for people with weak vision. Developed by The Royal National Institute for the Blind (RNIB).",
+    "homepage": "https://en.wikipedia.org/wiki/Tiresias_(typeface)",
+    "license": "GPL-3.0-or-later",
+    "url": "http://deb.debian.org/debian/pool/main/f/fonts-tiresias/fonts-tiresias_0.1.orig.tar.gz",
+    "hash": "19D197EFDA2734C583505F78A6A16FC2CB3A2B45485F4808E427C0FA891C98E3",
+    "extract_dir": "ttf-tiresias-0.1",
+    "installer": {
+        "script": [
+            "if (!(is_admin)) {",
+            "    error \"Administrator rights are required to install $app.\"",
+            "    exit 1",
+            "}",
+            "",
+            "Get-ChildItem $dir -filter '*.zip' | ForEach-Object {",
+            "    Expand-Archive $_.FullName \"$dir\" -Force",
+            "    Remove-Item $_.FullName",
+            "}",
+            "",
+            "Get-ChildItem $dir -filter '*.ttf' | ForEach-Object {",
+            "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
+            "    Copy-Item $_.FullName -destination \"$env:WINDIR\\Fonts\"",
+            "}"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "if (!(is_admin)) {",
+            "    error \"Administrator rights are required to install $app.\"",
+            "    exit 1",
+            "}",
+            "",
+            "Get-ChildItem $dir -filter '*.ttf' | ForEach-Object {",
+            "    Remove-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Force -ErrorAction SilentlyContinue",
+            "    Remove-Item \"$env:WINDIR\\Fonts\\$($_.Name)\" -Force -ErrorAction SilentlyContinue",
+            "}",
+            "",
+            "Write-Host \"Font 'jf-openhunnin' has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta"
+        ]
+    }
+}

--- a/bucket/Tiresias.json
+++ b/bucket/Tiresias.json
@@ -1,6 +1,6 @@
 {
     "version": "0.1",
-    "description": "Typeface degined for people with weak vision. Developed by The Royal National Institute for the Blind (RNIB).",
+    "description": "Typeface designed for people with weak vision. Developed by The Royal National Institute for the Blind (RNIB).",
     "homepage": "https://en.wikipedia.org/wiki/Tiresias_(typeface)",
     "license": "GPL-3.0-or-later",
     "url": "http://deb.debian.org/debian/pool/main/f/fonts-tiresias/fonts-tiresias_0.1.orig.tar.gz",
@@ -36,7 +36,7 @@
             "    Remove-Item \"$env:WINDIR\\Fonts\\$($_.Name)\" -Force -ErrorAction SilentlyContinue",
             "}",
             "",
-            "Write-Host \"Font 'jf-openhunnin' has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta"
+            "Write-Host \"Font 'Tiresias' has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta"
         ]
     }
 }


### PR DESCRIPTION
**Tiresias** ([Wikipedia](https://en.wikipedia.org/wiki/Tiresias_(typeface))) is a typeface designed for people with weak vision. It is developed by [The Royal National Institute for the Blind](https://www.rnib.org.uk/) (RNIB).

Notes:
* **file source**: The original homepage (http://tiresias.org/) is not maintained anymore. Also, I cannot find relative pages in the RNIB website. Therefore, I use [Debian package repo](https://packages.debian.org/buster/fonts-tiresias) as file source instead, since it is relatively stable.

* **homepage**:  using [Wikipedia](https://en.wikipedia.org/wiki/Tiresias_(typeface)) page as "homepage".

* The font's **license** is `GPL-3.0-or-later` according to Wikipedia and [official page in 2013 fetched from WebArchive](https://web.archive.org/web/20130306224222/http://www.tiresias.org/announcement.htm).


![](https://upload.wikimedia.org/wikipedia/commons/thumb/3/32/Tiresias_Specimen.svg/330px-Tiresias_Specimen.svg.png)