### PR TITLE
Pattaya: Add version 2.000

### DIFF
--- a/bucket/Pattaya.json
+++ b/bucket/Pattaya.json
@@ -1,0 +1,36 @@
+{
+    "version": "2.000",
+    "description": "Thai Lobster Font (Loopless)",
+    "homepage": "https://cadsondemak.github.io/pattaya/",
+    "license": "OFL-1.1",
+    "url": "https://github.com/cadsondemak/pattaya/raw/master/fonts/Pattaya-Regular.ttf",
+    "hash": "DE8EAF8469E85B3ED77AA0AEBEE38110292FFB12A47A14DA779C184536098345",
+    "installer": {
+        "script": [
+            "if (!(is_admin)) {",
+            "    error \"Administrator rights are required to install $app.\"",
+            "    exit 1",
+            "}",
+            "",
+            "Get-ChildItem $dir -filter '*.ttf' | ForEach-Object {",
+            "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
+            "    Copy-Item $_.FullName -destination \"$env:WINDIR\\Fonts\"",
+            "}"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "if (!(is_admin)) {",
+            "    error \"Administrator rights are required to install $app.\"",
+            "    exit 1",
+            "}",
+            "",
+            "Get-ChildItem $dir -filter '*ttf' | ForEach-Object {",
+            "    Remove-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Force -ErrorAction SilentlyContinue",
+            "    Remove-Item \"$env:WINDIR\\Fonts\\$($_.Name)\" -Force -ErrorAction SilentlyContinue",
+            "}",
+            "",
+            "Write-Host \"Font 'Pattaya' has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta"
+        ]
+    }
+}


### PR DESCRIPTION
**Pattaya** ([homepage](https://cadsondemak.github.io/pattaya/)) ([Github repo](https://github.com/cadsondemak/pattaya)) is the Thai version of [Lobster font](https://fonts.google.com/specimen/Lobster#standard-styles).

![u2](https://user-images.githubusercontent.com/27724471/126068068-4720c735-9bfd-4c86-a531-c5cadc3d7435.jpg)
![u1](https://user-images.githubusercontent.com/27724471/126068070-6dc68bd8-23ff-420c-8a8c-072da012f2dd.jpg)
![u3](https://user-images.githubusercontent.com/27724471/126068075-e08a5f33-2888-4c25-9d53-08e8b0f0a298.jpg)
