### PR TITLE
Sriracha: Add version 1.002

### DIFF
--- a/bucket/Sriracha.json
+++ b/bucket/Sriracha.json
@@ -1,0 +1,36 @@
+{
+    "version": "1.002",
+    "description": "Thai+Latin handwriting typeface, with an informal loopless + sans serif design.",
+    "homepage": "https://cadsondemak.github.io/sriracha/",
+    "license": "OFL-1.1",
+    "url": "https://github.com/cadsondemak/sriracha/raw/master/fonts/Sriracha-Regular.ttf",
+    "hash": "987B9A0793E5F49CF72B5D36655F523B21E8EE91CC92A6A2C2404C50463D960B",
+    "installer": {
+        "script": [
+            "if (!(is_admin)) {",
+            "    error \"Administrator rights are required to install $app.\"",
+            "    exit 1",
+            "}",
+            "",
+            "Get-ChildItem $dir -filter '*.ttf' | ForEach-Object {",
+            "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
+            "    Copy-Item $_.FullName -destination \"$env:WINDIR\\Fonts\"",
+            "}"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "if (!(is_admin)) {",
+            "    error \"Administrator rights are required to install $app.\"",
+            "    exit 1",
+            "}",
+            "",
+            "Get-ChildItem $dir -filter '*ttf' | ForEach-Object {",
+            "    Remove-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Force -ErrorAction SilentlyContinue",
+            "    Remove-Item \"$env:WINDIR\\Fonts\\$($_.Name)\" -Force -ErrorAction SilentlyContinue",
+            "}",
+            "",
+            "Write-Host \"Font 'Sriracha' has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta"
+        ]
+    }
+}


### PR DESCRIPTION
**Sriracha** is a Thai+Latin handwriting typeface, with an informal loopless + sans serif design.
([homepage](https://cadsondemak.github.io/sriracha/)) ([Github repo](https://github.com/cadsondemak/sriracha))

![u2](https://user-images.githubusercontent.com/27724471/126068495-55ec14a8-68eb-4f95-8568-91cf5371549c.jpg)
![u1](https://user-images.githubusercontent.com/27724471/126068493-0adef90e-97fe-4125-a0b7-5dc2c7dc4a93.jpg)

