### PR TITLE
IPAmj-Mincho: Replace with IPAex fonts

### DIFF
--- a/bucket/IPAex-Gothic.json
+++ b/bucket/IPAex-Gothic.json
@@ -1,19 +1,14 @@
 {
-    "version": "006.01",
+    "version": "004.01",
+    "description": "Free CJK font maintained by Japanese government agency. It covers a large set of characters.",
+    "homepage": "https://moji.or.jp/ipafont/",
     "license": {
         "identifier": "Freeware",
-        "url": "https://mojikiban.ipa.go.jp/1300.html#LicenseEng"
+        "url": "https://moji.or.jp/ipafont/license/"
     },
-    "homepage": "https://mojikiban.ipa.go.jp/1300.html",
-    "description": "Free CJK font maintained by Japanese government agency. It covers a large set of characters.",
-    "url": "https://mojikiban.ipa.go.jp/OSCDL/IPAmjMincho/ipamjm00601.zip",
-    "hash": "35494e0f2896f38b3f7369a8421a895cea6440a42c0a66ac95eab47d6ed25b68",
-    "checkver": {
-        "regex": "Ver\\.([\\d.]+)</h2>"
-    },
-    "autoupdate": {
-        "url": "https://mojikiban.ipa.go.jp/OSCDL/IPAmjMincho/ipamjm$cleanVersion.zip"
-    },
+    "url": "https://moji.or.jp/wp-content/ipafont/IPAexfont/ipaexg00401.zip",
+    "hash": "4ab6fee94bf6f94b3eeb31be2b73c559f738dc6b336d722d5301b1f3f592f850",
+    "extract_dir": "ipaexg00401",
     "installer": {
         "script": [
             "Get-ChildItem $dir -filter '*.ttf' | ForEach-Object {",
@@ -28,7 +23,14 @@
             "  Remove-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Force -ErrorAction SilentlyContinue",
             "  Remove-Item \"$env:windir\\Fonts\\$($_.Name)\" -Force -ErrorAction SilentlyContinue",
             "}",
-            "Write-Host \"The 'IPAmj Mincho' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta"
+            "Write-Host \"Font 'IPAex Gothic' has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta"
         ]
+    },
+    "checkver": {
+        "regex": "Ver\\.(\\d{3}\\.\\d{2}).*</span>"
+    },
+    "autoupdate": {
+        "url": "https://moji.or.jp/wp-content/ipafont/IPAexfont/ipaexg$cleanVersion.zip",
+        "extract_dir": "ipaexg$cleanVersion"
     }
 }

--- a/bucket/IPAex-Mincho.json
+++ b/bucket/IPAex-Mincho.json
@@ -1,0 +1,36 @@
+{
+    "version": "004.01",
+    "description": "Free CJK font maintained by Japanese government agency. It covers a large set of characters.",
+    "homepage": "https://moji.or.jp/ipafont/",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://moji.or.jp/ipafont/license/"
+    },
+    "url": "https://moji.or.jp/wp-content/ipafont/IPAexfont/ipaexm00401.zip",
+    "hash": "9604c77067396b4d2ab49816b3e18db741a70c8b1d43eb28669ae75cd1ce5237",
+    "extract_dir": "ipaexm00401",
+    "installer": {
+        "script": [
+            "Get-ChildItem $dir -filter '*.ttf' | ForEach-Object {",
+            "  New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
+            "  Copy-Item $_.FullName -destination \"$env:windir\\Fonts\"",
+            "}"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "Get-ChildItem $dir -filter '*.ttf' | ForEach-Object {",
+            "  Remove-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Force -ErrorAction SilentlyContinue",
+            "  Remove-Item \"$env:windir\\Fonts\\$($_.Name)\" -Force -ErrorAction SilentlyContinue",
+            "}",
+            "Write-Host \"Font 'IPAex Mincho' has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta"
+        ]
+    },
+    "checkver": {
+        "regex": "Ver\\.(\\d{3}\\.\\d{2}).*</span>"
+    },
+    "autoupdate": {
+        "url": "https://moji.or.jp/wp-content/ipafont/IPAexfont/ipaexm$cleanVersion.zip",
+        "extract_dir": "ipaexm$cleanVersion"
+    }
+}


### PR DESCRIPTION
**IPAmj Mincho** (previously added to this repo) is a free CJK font **maintained by Japanese government agency**. It covers a large set of characters.

This font has been recently replaced with **IPAex** font family.
(consists of 2 fonts: **IPAex Mincho** and **IPAex Gothic**)

Details about this upgrade can be found [here](https://moji.or.jp/ipafont/).
(It is written in Japanese. Sorry that I could not related essays written in English.)