### PR TITLE
Delugia: Update to version 2106.17

### DIFF
--- a/bucket/Delugia-Mono-Nerd-Font-Complete.json
+++ b/bucket/Delugia-Mono-Nerd-Font-Complete.json
@@ -1,12 +1,13 @@
 {
-    "version": "2102.25.1",
+    "version": "2106.17",
     "license": "OFL-1.1",
     "homepage": "https://github.com/adam7/delugia-code",
-    "url": "https://github.com/adam7/delugia-code/releases/download/v2102.25.1/Delugia.Mono.Nerd.Font.Complete.ttf",
-    "hash": "a90d73c3333c5720ff86bd042017c0b6b7093f0ccebbad70111246e397ed4631",
+    "url": "https://github.com/adam7/delugia-code/releases/download/v2106.17/delugia-mono-complete.zip",
+    "hash": "23c61e63ab125ed3045d4bd2fe788c0552dd7152f698bca9eb3cae1bfc98c760",
+    "extract_dir": "delugia-mono-complete",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/adam7/delugia-code/releases/download/v$version/Delugia.Mono.Nerd.Font.Complete.ttf"
+        "url": "https://github.com/adam7/delugia-code/releases/download/v$version/delugia-mono-complete.zip"
     },
     "installer": {
         "script": [

--- a/bucket/Delugia-Mono-Nerd-Font.json
+++ b/bucket/Delugia-Mono-Nerd-Font.json
@@ -1,12 +1,13 @@
 {
-    "version": "2102.25.1",
+    "version": "2106.17",
     "license": "OFL-1.1",
     "homepage": "https://github.com/adam7/delugia-code",
-    "url": "https://github.com/adam7/delugia-code/releases/download/v2102.25.1/Delugia.Mono.Nerd.Font.ttf",
-    "hash": "20dacddefd02d1699b21a87ce84e2409356cbfb5651b09c893b5d138d32f03c7",
+    "url": "https://github.com/adam7/delugia-code/releases/download/v2106.17/delugia-mono-powerline.zip",
+    "hash": "c0e7b6cc4c8370ea167fd8ade94f3192286fe26c2a97cbabf173581b114cf28d",
+    "extract_dir": "delugia-mono-powerline",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/adam7/delugia-code/releases/download/v$version/Delugia.Mono.Nerd.Font.ttf"
+        "url": "https://github.com/adam7/delugia-code/releases/download/v$version/delugia-mono-powerline.zip"
     },
     "installer": {
         "script": [

--- a/bucket/Delugia-Nerd-Font-Book.json
+++ b/bucket/Delugia-Nerd-Font-Book.json
@@ -1,12 +1,13 @@
 {
-    "version": "2102.25.1",
+    "version": "2106.17",
     "license": "OFL-1.1",
     "homepage": "https://github.com/adam7/delugia-code",
-    "url": "https://github.com/adam7/delugia-code/releases/download/v2102.25.1/Delugia.Nerd.Font.Book.ttf",
-    "hash": "bbf475ab4d6faeb9e7fae2bdf43e9ca778ec6bcf6c2e3006d8c0730611a4109f",
+    "url": "https://github.com/adam7/delugia-code/releases/download/v2106.17/delugia-book.zip",
+    "hash": "376a60ab222870e50311b0a077a0a7b38a48a911827649fc93ac7119493c5795",
+    "extract_dir": "delugia-book",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/adam7/delugia-code/releases/download/v$version/Delugia.Nerd.Font.Book.ttf"
+        "url": "https://github.com/adam7/delugia-code/releases/download/v$version/delugia-book.zip"
     },
     "installer": {
         "script": [

--- a/bucket/Delugia-Nerd-Font-Complete.json
+++ b/bucket/Delugia-Nerd-Font-Complete.json
@@ -1,12 +1,13 @@
 {
-    "version": "2102.25.1",
+    "version": "2106.17",
     "license": "OFL-1.1",
     "homepage": "https://github.com/adam7/delugia-code",
-    "url": "https://github.com/adam7/delugia-code/releases/download/v2102.25.1/Delugia.Nerd.Font.Complete.ttf",
-    "hash": "c4a3eee4215995b19bbfd61da262ace1e3e8da78e9c270f1d3a41666dcded759",
+    "url": "https://github.com/adam7/delugia-code/releases/download/v2106.17/delugia-complete.zip",
+    "hash": "1195d53ccd4a151891b6efbf14bc4a7eb85819ddbb627bc4a893e4f87db30682",
+    "extract_dir": "delugia-complete",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/adam7/delugia-code/releases/download/v$version/Delugia.Nerd.Font.Complete.ttf"
+        "url": "https://github.com/adam7/delugia-code/releases/download/v$version/delugia-complete.zip"
     },
     "installer": {
         "script": [

--- a/bucket/Delugia-Nerd-Font.json
+++ b/bucket/Delugia-Nerd-Font.json
@@ -1,12 +1,13 @@
 {
-    "version": "2102.25.1",
+    "version": "2106.17",
     "license": "OFL-1.1",
     "homepage": "https://github.com/adam7/delugia-code",
-    "url": "https://github.com/adam7/delugia-code/releases/download/v2102.25.1/Delugia.Nerd.Font.ttf",
-    "hash": "523e77ddab9d2cd947190378c62676c4f73eb995193384fe2f571116dc5152ed",
+    "url": "https://github.com/adam7/delugia-code/releases/download/v2106.17/delugia-powerline.zip",
+    "hash": "6a8518ab1943630af9488747fede9074af32ab8c1dca9ad951c07ea597553644",
+    "extract_dir": "delugia-powerline",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/adam7/delugia-code/releases/download/v$version/Delugia.Nerd.Font.ttf"
+        "url": "https://github.com/adam7/delugia-code/releases/download/v$version/delugia-powerline.zip"
     },
     "installer": {
         "script": [


### PR DESCRIPTION
Since [version 2105.24.2](https://github.com/adam7/delugia-code/releases/tag/v2105.24.2), the download assets on Delugia's release page changed from `.ttf` font files to `.zip` files.

So I change the `url` and `autoupdate.url` of each Delugia's manifests accordingly.
Also add `extract_dir` part according to each zip file's structure.