### PR TITLE
Hasklig: Update to version 1.2

### DIFF
--- a/bucket/Hasklig.json
+++ b/bucket/Hasklig.json
@@ -1,10 +1,15 @@
 {
-    "version": "1.1",
+    "version": "1.2",
     "description": "Code font with monospaced ligatures based on Source Code Pro",
     "homepage": "https://github.com/i-tu/Hasklig",
     "license": "OFL-1.1",
-    "url": "https://github.com/i-tu/Hasklig/releases/download/1.1/Hasklig-1.1.zip",
-    "hash": "98eccec22bc0ae3838a099a911230f62197e681b6a6c30e5149c52f5fc6a95c3",
+    "url": "https://github.com/i-tu/Hasklig/releases/download/v1.2/Hasklig-1.2.zip",
+    "hash": "9cd35a7449b220dc84f9516c57817e147003fc905a477f1ec727816d9d8a81d4",
+    "extract_dir": "OTF",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/i-tu/Hasklig/releases/download/v$version/Hasklig-$version.zip"
+    },
     "installer": {
         "script": [
             "if(!(is_admin)) { error \"Admin rights are required, please run 'sudo scoop install $app'\"; exit 1 }",
@@ -23,9 +28,5 @@
             "}",
             "Write-Host \"The 'Hasklig' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta"
         ]
-    },
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/i-tu/Hasklig/releases/download/$version/Hasklig-$version.zip"
     }
 }


### PR DESCRIPTION
- Update `autoupdate.url` because the upstream repository's tag version change from `1.1` to `v1.2`
- Add `extract_dir` part because the zip file's structure has changed