### PR TITLE
Add `Ash258/Scoop-GithubActions` to do automated tasks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,3 +4,6 @@ indent_size = 4
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[*.yml]
+indent_size = 2

--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -1,0 +1,17 @@
+name: Issues
+
+on:
+  issues:
+    types: [opened, labeled]
+
+jobs:
+  issueHandler:
+    runs-on: windows-latest
+    name: Issue Verification
+    steps:
+      - uses: actions/checkout@main
+      - name: Verify Issue
+        uses: Ash258/Scoop-GithubActions@stable-win
+        if: github.event.action == 'opened' || (github.event.action == 'labeled' && contains(github.event.issue.labels.*.name, 'verify'))
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issue_comment.yml
+++ b/.github/workflows/issue_comment.yml
@@ -1,0 +1,17 @@
+name: Commented Pull Request
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  pullRequestHandler:
+    name: Pull Request Validator
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@main
+      - name: Pull Request Validation
+        uses: Ash258/Scoop-GithubActions@stable-win
+        if: startsWith(github.event.comment.body, '/verify')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,16 @@
+name: Pull Requests
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  pullRequestHandler:
+    name: Pull Request Validator
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@main
+      - name: Pull Request Validation
+        uses: Ash258/Scoop-GithubActions@stable-win
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -1,0 +1,18 @@
+name: Excavator
+
+on:
+  # runs every hour
+  schedule:
+    - cron: "0 * * * *"
+
+jobs:
+  excavate:
+    name: Excavator
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@main
+      - name: Excavate
+        uses: Ash258/Scoop-GithubActions@stable-win
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SKIP_UPDATED: "1"


### PR DESCRIPTION
Close #135

- Tweak `.editorconfig`, because `.yml` file are usually using 2 space as indentation.
- Currently, I do not set `GITH_MAIL` environment variable because I think commits made by CI does not count as contributions by anyone. But it is just my opinion 😊 and can be changed if needed.

Some information about `GITH_EMAIL` environment variable is not set, quote from [Ash258/Scoop-GithubActions's README](https://github.com/Ash258/Scoop-GithubActions/blob/stable-win/README.md#available-environment-variables)
>`GITH_EMAIL` environment variable is not required since [1.0.1](https://github.com/Ash258/Scoop-GithubActions/releases/tag/1.0.1), but it is recommended.
If email is not specified, commits will not be pushed using account bounded to the email. This will lead to not adding contributions. ([See as example commit from github action without user's email](https://github.com/phips28/gh-action-bump-version/commit/adda5b22b3c785eb69d328f91dadb49a4c34a82e))