### PR TITLE
LeagueMono(-static)(-variable): Add version 2.220

### DIFF
--- a/bucket/LeagueMono-static.json
+++ b/bucket/LeagueMono-static.json
@@ -1,0 +1,49 @@
+{
+    "version": "2.220",
+    "description": "Sans-serif font featuring variable character spaces. Inspired by Fira Mono, Libertinus Mono, and Courier.",
+    "homepage": "https://www.theleagueofmoveabletype.com/league-mono",
+    "license": "OFL-1.1",
+    "notes": [
+        "You are installing the static version of LeagueMono.",
+        "This package contains 40 pre-defined styles, instead of a variable TTF font. (for better compatibility)",
+        "For variable TTF version, install 'LeagueMono-variable'."
+    ],
+    "url": "https://github.com/theleagueof/league-mono/releases/download/2.220/LeagueMono-2.220.zip",
+    "hash": "79135d873ee5c6fc4b84926bfc96fede198259ccb65d26edce8badf2fad42694",
+    "extract_dir": "LeagueMono-2.220/static/TTF",
+    "installer": {
+        "script": [
+            "if (!(is_admin)) {",
+            "    error \"Administrator rights are required to install $app.\"",
+            "    exit 1",
+            "}",
+            "",
+            "Get-ChildItem $dir -filter '*.ttf' | ForEach-Object {",
+            "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
+            "    Copy-Item $_.FullName -destination \"$env:WINDIR\\Fonts\"",
+            "}"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "if (!(is_admin)) {",
+            "    error \"Administrator rights are required to install $app.\"",
+            "    exit 1",
+            "}",
+            "",
+            "Get-ChildItem $dir -filter '*ttf' | ForEach-Object {",
+            "    Remove-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Force -ErrorAction SilentlyContinue",
+            "    Remove-Item \"$env:WINDIR\\Fonts\\$($_.Name)\" -Force -ErrorAction SilentlyContinue",
+            "}",
+            "",
+            "Write-Host \"Font 'League Mono' has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta"
+        ]
+    },
+    "checkver": {
+        "github": "https://github.com/theleagueof/league-mono"
+    },
+    "autoupdate": {
+        "url": "https://github.com/theleagueof/league-mono/releases/download/$version/LeagueMono-$version.zip",
+        "extract_dir": "LeagueMono-$version/static/TTF"
+    }
+}

--- a/bucket/LeagueMono-variable.json
+++ b/bucket/LeagueMono-variable.json
@@ -1,0 +1,51 @@
+{
+    "version": "2.220",
+    "description": "Sans-serif font featuring variable character spaces. Inspired by Fira Mono, Libertinus Mono, and Courier.",
+    "homepage": "https://www.theleagueofmoveabletype.com/league-mono",
+    "license": "OFL-1.1",
+    "notes": [
+        "You are installing the variable version of LeagueMono.",
+        "This package contains a variable TTF font, which users can adjust font weight and character width on-the-fly.",
+        "However, some applications may not support the feature.",
+        "The 'static' version provides better compatibility, which contains 40 pre-defined styles instead of a single variable TTF font.",
+        "For static version, install 'LeagueMono-static'."
+    ],
+    "url": "https://github.com/theleagueof/league-mono/releases/download/2.220/LeagueMono-2.220.zip",
+    "hash": "79135d873ee5c6fc4b84926bfc96fede198259ccb65d26edce8badf2fad42694",
+    "extract_dir": "LeagueMono-2.220/variable/TTF",
+    "installer": {
+        "script": [
+            "if (!(is_admin)) {",
+            "    error \"Administrator rights are required to install $app.\"",
+            "    exit 1",
+            "}",
+            "",
+            "Get-ChildItem $dir -filter '*.ttf' | ForEach-Object {",
+            "    New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $_.Name -Force | Out-Null",
+            "    Copy-Item $_.FullName -destination \"$env:WINDIR\\Fonts\"",
+            "}"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "if (!(is_admin)) {",
+            "    error \"Administrator rights are required to install $app.\"",
+            "    exit 1",
+            "}",
+            "",
+            "Get-ChildItem $dir -filter '*ttf' | ForEach-Object {",
+            "    Remove-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Force -ErrorAction SilentlyContinue",
+            "    Remove-Item \"$env:WINDIR\\Fonts\\$($_.Name)\" -Force -ErrorAction SilentlyContinue",
+            "}",
+            "",
+            "Write-Host \"Font 'League Mono' has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta"
+        ]
+    },
+    "checkver": {
+        "github": "https://github.com/theleagueof/league-mono"
+    },
+    "autoupdate": {
+        "url": "https://github.com/theleagueof/league-mono/releases/download/$version/LeagueMono-$version.zip",
+        "extract_dir": "LeagueMono-$version/variable/TTF"
+    }
+}


### PR DESCRIPTION
* Requested in #101

* If there is any problem (or some other suggestions), please tell me. Or, merge this PR if you think the manifest looks fine to you. Thank you.

* **League Mono** is Sans-serif font **featuring variable character spaces**. Inspired by Fira Mono, Libertinus Mono, and Courier.

* The author provides 2 sets of the font:
**static**: 40 pre-defined styles. (for better compatibility)
**variable**: A single variable TTF font, which enables users to adjust font weight and char width **on-the-fly**. However, the feature may not be supported by some apps.
Therefore, I added some descriptions about the difference in the `notes` section. 



* Additional info:
[homepage](https://www.theleagueofmoveabletype.com/league-mono)
[Github source repo](https://github.com/theleagueof/league-mono)
[License](https://github.com/theleagueof/league-mono/blob/master/OFL.md)


![](https://raw.githubusercontent.com/sursly/leaguemono/master/imgs/variable-A-B.png)
![](https://raw.githubusercontent.com/sursly/leaguemono/master/imgs/lm-sliders-fincksite.gif)