### PR TITLE
basic-comical-nc@1.00: regex fix

### DIFF
--- a/bucket/basic-comical-nc.json
+++ b/bucket/basic-comical-nc.json
@@ -1,12 +1,12 @@
 {
-    "version": "1.",
+    "version": "1.00",
     "license": "Unlicensed",
     "homepage": "https://www.dafont.com/basic-comical-nc.font",
     "url": "https://dl.dafont.com/dl/?f=basic_comical_nc#/basic-comical-nc.zip",
     "hash": "ea01596811396ea7fe26c08daebfcb4b6abdea1551c654f8208b8061c898311f",
     "checkver": {
         "url": "https://www.wfonts.com/font/basic-comical-nc",
-        "regex": "Version ([\\d.]+)"
+        "regex": "<p>Version ([\\d.]+)"
     },
     "autoupdate": {
         "url": "https://dl.dafont.com/dl/?f=basic_comical_nc#/basic-comical-nc.zip"


### PR DESCRIPTION
- Add additional `<p>` to `checkver.regex` to make sure checkver script will get the correct version number from the web page

Close #149