### PR TITLE
Make Open-Sans nightly

### DIFF
--- a/bucket/Open-Sans.json
+++ b/bucket/Open-Sans.json
@@ -1,10 +1,9 @@
 {
-    "version": "1",
+    "version": "nightly",
     "description": "Humanist sans-serif typeface.",
     "homepage": "https://fonts.google.com/specimen/Open+Sans",
     "license": "Apache-2.0",
     "url": "https://fonts.google.com/download?family=Open+Sans#/fonts.zip",
-    "hash": "7321d655107579e8f8bde541257de4355fc3e9b7cb2f999a944dfdbf8743f2e3",
     "installer": {
         "script": [
             "if (!(is_admin)) {",


### PR DESCRIPTION
The downloaded file will have different hash each time, similar to the past issue of Raleway (#80) which fixed by make it nightly (c11fce3df0d3e900a4dcece4f71d193311a26bd2)