### PR TITLE
Move pre-install scripts to `pre_install` section

### DIFF
--- a/bucket/SarasaGothic-CL.json
+++ b/bucket/SarasaGothic-CL.json
@@ -9,10 +9,12 @@
     "autoupdate": {
         "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v$version/sarasa-gothic-ttf-$version.7z#/dl.7z_"
     },
+    "pre_install ": [
+        "Invoke-ExternalCommand 7z -ArgumentList('e', \"$dir\\dl.7z_\" ,\"-o$dir\", '*-cl-*.ttf') | Out-Null",
+        "Remove-Item \"$dir\\dl.7z_\""
+    ],
     "installer": {
         "script": [
-            "Invoke-ExternalCommand 7z -ArgumentList('e', \"$dir\\dl.7z_\" ,\"-o$dir\", '*-cl-*.ttf') | Out-Null",
-            "Remove-Item \"$dir\\dl.7z_\"",
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
             "$windows1809BuildNumber = 17763",
             "$isPerUserFontInstallationSupported = $currentBuildNumber -ge $windows1809BuildNumber",

--- a/bucket/SarasaGothic-HK.json
+++ b/bucket/SarasaGothic-HK.json
@@ -9,10 +9,12 @@
     "autoupdate": {
         "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v$version/sarasa-gothic-ttf-$version.7z#/dl.7z_"
     },
+    "pre_install ": [
+        "Invoke-ExternalCommand 7z -ArgumentList('e', \"$dir\\dl.7z_\" ,\"-o$dir\", '*-hk-*.ttf') | Out-Null",
+        "Remove-Item \"$dir\\dl.7z_\""
+    ],
     "installer": {
         "script": [
-            "Invoke-ExternalCommand 7z -ArgumentList('e', \"$dir\\dl.7z_\" ,\"-o$dir\", '*-hk-*.ttf') | Out-Null",
-            "Remove-Item \"$dir\\dl.7z_\"",
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
             "$windows1809BuildNumber = 17763",
             "$isPerUserFontInstallationSupported = $currentBuildNumber -ge $windows1809BuildNumber",

--- a/bucket/SarasaGothic-J.json
+++ b/bucket/SarasaGothic-J.json
@@ -9,10 +9,12 @@
     "autoupdate": {
         "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v$version/sarasa-gothic-ttf-$version.7z#/dl.7z_"
     },
+    "pre_install ": [
+        "Invoke-ExternalCommand 7z -ArgumentList('e', \"$dir\\dl.7z_\" ,\"-o$dir\", '*-j-*.ttf') | Out-Null",
+        "Remove-Item \"$dir\\dl.7z_\""
+    ],
     "installer": {
         "script": [
-            "Invoke-ExternalCommand 7z -ArgumentList('e', \"$dir\\dl.7z_\" ,\"-o$dir\", '*-j-*.ttf') | Out-Null",
-            "Remove-Item \"$dir\\dl.7z_\"",
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
             "$windows1809BuildNumber = 17763",
             "$isPerUserFontInstallationSupported = $currentBuildNumber -ge $windows1809BuildNumber",

--- a/bucket/SarasaGothic-K.json
+++ b/bucket/SarasaGothic-K.json
@@ -9,10 +9,12 @@
     "autoupdate": {
         "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v$version/sarasa-gothic-ttf-$version.7z#/dl.7z_"
     },
+    "pre_install ": [
+        "Invoke-ExternalCommand 7z -ArgumentList('e', \"$dir\\dl.7z_\" ,\"-o$dir\", '*-k-*.ttf') | Out-Null",
+        "Remove-Item \"$dir\\dl.7z_\""
+    ],
     "installer": {
         "script": [
-            "Invoke-ExternalCommand 7z -ArgumentList('e', \"$dir\\dl.7z_\" ,\"-o$dir\", '*-k-*.ttf') | Out-Null",
-            "Remove-Item \"$dir\\dl.7z_\"",
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
             "$windows1809BuildNumber = 17763",
             "$isPerUserFontInstallationSupported = $currentBuildNumber -ge $windows1809BuildNumber",

--- a/bucket/SarasaGothic-SC.json
+++ b/bucket/SarasaGothic-SC.json
@@ -9,10 +9,12 @@
     "autoupdate": {
         "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v$version/sarasa-gothic-ttf-$version.7z#/dl.7z_"
     },
+    "pre_install ": [
+        "Invoke-ExternalCommand 7z -ArgumentList('e', \"$dir\\dl.7z_\" ,\"-o$dir\", '*-sc-*.ttf') | Out-Null",
+        "Remove-Item \"$dir\\dl.7z_\""
+    ],
     "installer": {
         "script": [
-            "Invoke-ExternalCommand 7z -ArgumentList('e', \"$dir\\dl.7z_\" ,\"-o$dir\", '*-sc-*.ttf') | Out-Null",
-            "Remove-Item \"$dir\\dl.7z_\"",
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
             "$windows1809BuildNumber = 17763",
             "$isPerUserFontInstallationSupported = $currentBuildNumber -ge $windows1809BuildNumber",

--- a/bucket/SarasaGothic-TC.json
+++ b/bucket/SarasaGothic-TC.json
@@ -9,10 +9,12 @@
     "autoupdate": {
         "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v$version/sarasa-gothic-ttf-$version.7z#/dl.7z_"
     },
+    "pre_install ": [
+        "Invoke-ExternalCommand 7z -ArgumentList('e', \"$dir\\dl.7z_\" ,\"-o$dir\", '*-tc-*.ttf') | Out-Null",
+        "Remove-Item \"$dir\\dl.7z_\""
+    ],
     "installer": {
         "script": [
-            "Invoke-ExternalCommand 7z -ArgumentList('e', \"$dir\\dl.7z_\" ,\"-o$dir\", '*-tc-*.ttf') | Out-Null",
-            "Remove-Item \"$dir\\dl.7z_\"",
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
             "$windows1809BuildNumber = 17763",
             "$isPerUserFontInstallationSupported = $currentBuildNumber -ge $windows1809BuildNumber",

--- a/bucket/Tiresias.json
+++ b/bucket/Tiresias.json
@@ -6,12 +6,14 @@
     "url": "http://deb.debian.org/debian/pool/main/f/fonts-tiresias/fonts-tiresias_0.1.orig.tar.gz",
     "hash": "19D197EFDA2734C583505F78A6A16FC2CB3A2B45485F4808E427C0FA891C98E3",
     "extract_dir": "ttf-tiresias-0.1",
+    "pre_install ": [
+        "Get-ChildItem $dir -Filter '*.zip' | ForEach-Object {",
+        "    Expand-Archive $_.FullName $dir -Force",
+        "    Remove-Item $_.FullName",
+        "}"
+    ],
     "installer": {
         "script": [
-            "Get-ChildItem $dir -Filter '*.zip' | ForEach-Object {",
-            "    Expand-Archive $_.FullName $dir -Force",
-            "    Remove-Item $_.FullName",
-            "}",
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
             "$windows1809BuildNumber = 17763",
             "$isPerUserFontInstallationSupported = $currentBuildNumber -ge $windows1809BuildNumber",

--- a/bucket/andika-compact.json
+++ b/bucket/andika-compact.json
@@ -11,10 +11,12 @@
     "autoupdate": {
         "url": "https://software.sil.org/downloads/r/andika/AndikaCompact-$version.zip"
     },
+    "pre_install ": [
+        "Move-Item $dir\\AndikaCompact-$version\\* $dir",
+        "Remove-Item $dir\\AndikaCompact-$version"
+    ],
     "installer": {
         "script": [
-            "Move-Item $dir\\AndikaCompact-$version\\* $dir",
-            "Remove-Item $dir\\AndikaCompact-$version",
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
             "$windows1809BuildNumber = 17763",
             "$isPerUserFontInstallationSupported = $currentBuildNumber -ge $windows1809BuildNumber",

--- a/bucket/andika-new-basic.json
+++ b/bucket/andika-new-basic.json
@@ -11,10 +11,12 @@
     "autoupdate": {
         "url": "https://software.sil.org/downloads/r/andika/AndikaNewBasic-$version.zip"
     },
+    "pre_install ": [
+        "Move-Item $dir\\AndikaNewBasic-$version\\* $dir",
+        "Remove-Item $dir\\AndikaNewBasic-$version"
+    ],
     "installer": {
         "script": [
-            "Move-Item $dir\\AndikaNewBasic-$version\\* $dir",
-            "Remove-Item $dir\\AndikaNewBasic-$version",
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
             "$windows1809BuildNumber = 17763",
             "$isPerUserFontInstallationSupported = $currentBuildNumber -ge $windows1809BuildNumber",

--- a/bucket/andika.json
+++ b/bucket/andika.json
@@ -11,10 +11,12 @@
     "autoupdate": {
         "url": "https://software.sil.org/downloads/r/andika/Andika-$version.zip"
     },
+    "pre_install ": [
+        "Move-Item $dir\\Andika-$version\\* $dir",
+        "Remove-Item $dir\\Andika-$version"
+    ],
     "installer": {
         "script": [
-            "Move-Item $dir\\Andika-$version\\* $dir",
-            "Remove-Item $dir\\Andika-$version",
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
             "$windows1809BuildNumber = 17763",
             "$isPerUserFontInstallationSupported = $currentBuildNumber -ge $windows1809BuildNumber",


### PR DESCRIPTION
A minor refactor, move pre-install scripts (the scripts above the line `$currentBuildNumber = [int] ...`) into the `pre_install` section