### PR TITLE
SarasaGothic: Fix issue in 'path with spaces'

### DIFF
--- a/bucket/SarasaGothic-CL.json
+++ b/bucket/SarasaGothic-CL.json
@@ -10,7 +10,7 @@
         "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v$version/sarasa-gothic-ttf-$version.7z#/dl.7z_"
     },
     "pre_install": [
-        "Invoke-ExternalCommand 7z -ArgumentList('e', \"$dir\\dl.7z_\" ,\"-o$dir\", '*-cl-*.ttf') | Out-Null",
+        "Invoke-ExternalCommand 7z -ArgumentList('e', \"`\"$dir\\dl.7z_`\"\" ,\"`\"-o$dir`\"\", '*-cl-*.ttf') | Out-Null",
         "Remove-Item \"$dir\\dl.7z_\""
     ],
     "installer": {

--- a/bucket/SarasaGothic-HK.json
+++ b/bucket/SarasaGothic-HK.json
@@ -10,7 +10,7 @@
         "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v$version/sarasa-gothic-ttf-$version.7z#/dl.7z_"
     },
     "pre_install": [
-        "Invoke-ExternalCommand 7z -ArgumentList('e', \"$dir\\dl.7z_\" ,\"-o$dir\", '*-hk-*.ttf') | Out-Null",
+        "Invoke-ExternalCommand 7z -ArgumentList('e', \"`\"$dir\\dl.7z_`\"\" ,\"`\"-o$dir`\"\", '*-hk-*.ttf') | Out-Null",
         "Remove-Item \"$dir\\dl.7z_\""
     ],
     "installer": {

--- a/bucket/SarasaGothic-J.json
+++ b/bucket/SarasaGothic-J.json
@@ -10,7 +10,7 @@
         "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v$version/sarasa-gothic-ttf-$version.7z#/dl.7z_"
     },
     "pre_install": [
-        "Invoke-ExternalCommand 7z -ArgumentList('e', \"$dir\\dl.7z_\" ,\"-o$dir\", '*-j-*.ttf') | Out-Null",
+        "Invoke-ExternalCommand 7z -ArgumentList('e', \"`\"$dir\\dl.7z_`\"\" ,\"`\"-o$dir`\"\", '*-j-*.ttf') | Out-Null",
         "Remove-Item \"$dir\\dl.7z_\""
     ],
     "installer": {

--- a/bucket/SarasaGothic-K.json
+++ b/bucket/SarasaGothic-K.json
@@ -10,7 +10,7 @@
         "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v$version/sarasa-gothic-ttf-$version.7z#/dl.7z_"
     },
     "pre_install": [
-        "Invoke-ExternalCommand 7z -ArgumentList('e', \"$dir\\dl.7z_\" ,\"-o$dir\", '*-k-*.ttf') | Out-Null",
+        "Invoke-ExternalCommand 7z -ArgumentList('e', \"`\"$dir\\dl.7z_`\"\" ,\"`\"-o$dir`\"\", '*-k-*.ttf') | Out-Null",
         "Remove-Item \"$dir\\dl.7z_\""
     ],
     "installer": {

--- a/bucket/SarasaGothic-SC.json
+++ b/bucket/SarasaGothic-SC.json
@@ -10,7 +10,7 @@
         "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v$version/sarasa-gothic-ttf-$version.7z#/dl.7z_"
     },
     "pre_install": [
-        "Invoke-ExternalCommand 7z -ArgumentList('e', \"$dir\\dl.7z_\" ,\"-o$dir\", '*-sc-*.ttf') | Out-Null",
+        "Invoke-ExternalCommand 7z -ArgumentList('e', \"`\"$dir\\dl.7z_`\"\" ,\"`\"-o$dir`\"\", '*-sc-*.ttf') | Out-Null",
         "Remove-Item \"$dir\\dl.7z_\""
     ],
     "installer": {

--- a/bucket/SarasaGothic-TC.json
+++ b/bucket/SarasaGothic-TC.json
@@ -10,7 +10,7 @@
         "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v$version/sarasa-gothic-ttf-$version.7z#/dl.7z_"
     },
     "pre_install": [
-        "Invoke-ExternalCommand 7z -ArgumentList('e', \"$dir\\dl.7z_\" ,\"-o$dir\", '*-tc-*.ttf') | Out-Null",
+        "Invoke-ExternalCommand 7z -ArgumentList('e', \"`\"$dir\\dl.7z_`\"\" ,\"`\"-o$dir`\"\", '*-tc-*.ttf') | Out-Null",
         "Remove-Item \"$dir\\dl.7z_\""
     ],
     "installer": {


### PR DESCRIPTION
This will avoid 7-zip extraction error for users whose **Scoop directory** contains spaces.

(e.g. `C:\Users\John Smith\scoop`) 