### PR TITLE
LXGW-Bright(-Classic): Add version 2.152

### DIFF
--- a/bucket/LXGW-Bright-Classic.json
+++ b/bucket/LXGW-Bright-Classic.json
@@ -1,0 +1,74 @@
+{
+    "version": "2.152",
+    "description": "An open-source Traditional Chinese font. Combination of LXGW WenKai TC (霞鹜文楷 TC) and Ysabeau Office",
+    "homepage": "https://github.com/lxgw/LxgwBright",
+    "license": "OFL-1.1",
+    "url": [
+        "https://raw.githubusercontent.com/lxgw/LxgwBright/main/OTF/LXGWBrightClassic-Italic.otf",
+        "https://raw.githubusercontent.com/lxgw/LxgwBright/main/OTF/LXGWBrightClassic-Medium.otf",
+        "https://raw.githubusercontent.com/lxgw/LxgwBright/main/OTF/LXGWBrightClassic-MediumItalic.otf",
+        "https://raw.githubusercontent.com/lxgw/LxgwBright/main/OTF/LXGWBrightClassic-Regular.otf",
+        "https://raw.githubusercontent.com/lxgw/LxgwBright/main/OTF/LXGWBrightClassic-SemiLight.otf",
+        "https://raw.githubusercontent.com/lxgw/LxgwBright/main/OTF/LXGWBrightClassic-SemiLightItalic.otf"
+    ],
+    "hash": [
+        "82a23d1a2232e37c59d998b9f6f29f8b941e85136b829c3374c62ecbca92b249",
+        "447ea5ef2657f0f68ecfc37393409050624e43fb995bdb9fb8377f1d3c99680d",
+        "df670f43c7956d65b074687c0ae7b937a97a1a4dc6d82c11e06584e7b89dcc63",
+        "4afe87da80ca5fd8a102349dc5994f82b99a42dd4b9881480f93ff7f7993985f",
+        "67b515c814473a940051219ad4a5f98dc68ded3751de382de72db4701104e97c",
+        "f6fc837ecd4c1f458d69e886a91058802bcb8773b551cfa84b6bf23c5a08d072"
+    ],
+    "installer": {
+        "script": [
+            "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
+            "$windows1809BuildNumber = 17763",
+            "$isPerUserFontInstallationSupported = $currentBuildNumber -ge $windows1809BuildNumber",
+            "$isFontInstallationForAllUsers = $global -or !$isPerUserFontInstallationSupported",
+            "if ($isFontInstallationForAllUsers -and !(is_admin)) {",
+            "    error \"Administrator rights are required to install $app.\"",
+            "    exit 1",
+            "}",
+            "$fontInstallDir = if ($isFontInstallationForAllUsers) { \"$env:windir\\Fonts\" } else { \"$env:LOCALAPPDATA\\Microsoft\\Windows\\Fonts\" }",
+            "$registryRoot = if ($isFontInstallationForAllUsers) { \"HKLM\" } else { \"HKCU\" }",
+            "$registryKey = \"${registryRoot}:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\"",
+            "New-Item $fontInstallDir -ItemType Directory -ErrorAction SilentlyContinue | Out-Null",
+            "Get-ChildItem $dir -Filter '*.otf' | ForEach-Object {",
+            "    $value = if ($isFontInstallationForAllUsers) { $_.Name } else { \"$fontInstallDir\\$($_.Name)\" }",
+            "    New-ItemProperty -Path $registryKey -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $value -Force | Out-Null",
+            "    Copy-Item $_.FullName -Destination $fontInstallDir",
+            "}"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
+            "$windows1809BuildNumber = 17763",
+            "$isPerUserFontInstallationSupported = $currentBuildNumber -ge $windows1809BuildNumber",
+            "$isFontInstallationForAllUsers = $global -or !$isPerUserFontInstallationSupported",
+            "if ($isFontInstallationForAllUsers -and !(is_admin)) {",
+            "    error \"Administrator rights are required to uninstall $app.\"",
+            "    exit 1",
+            "}",
+            "$fontInstallDir = if ($isFontInstallationForAllUsers) { \"$env:windir\\Fonts\" } else { \"$env:LOCALAPPDATA\\Microsoft\\Windows\\Fonts\" }",
+            "$registryRoot = if ($isFontInstallationForAllUsers) { \"HKLM\" } else { \"HKCU\" }",
+            "$registryKey = \"${registryRoot}:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\"",
+            "Get-ChildItem $dir -Filter '*.otf' | ForEach-Object {",
+            "    Remove-ItemProperty -Path $registryKey -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Force -ErrorAction SilentlyContinue",
+            "    Remove-Item \"$fontInstallDir\\$($_.Name)\" -Force -ErrorAction SilentlyContinue",
+            "}",
+            "Write-Host \"Font family 'LXGW Bright Classic' has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta"
+        ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": [
+            "https://raw.githubusercontent.com/lxgw/LxgwBright/main/OTF/LXGWBrightClassic-Italic.otf",
+            "https://raw.githubusercontent.com/lxgw/LxgwBright/main/OTF/LXGWBrightClassic-Medium.otf",
+            "https://raw.githubusercontent.com/lxgw/LxgwBright/main/OTF/LXGWBrightClassic-MediumItalic.otf",
+            "https://raw.githubusercontent.com/lxgw/LxgwBright/main/OTF/LXGWBrightClassic-Regular.otf",
+            "https://raw.githubusercontent.com/lxgw/LxgwBright/main/OTF/LXGWBrightClassic-SemiLight.otf",
+            "https://raw.githubusercontent.com/lxgw/LxgwBright/main/OTF/LXGWBrightClassic-SemiLightItalic.otf"
+        ]
+    }
+}

--- a/bucket/LXGW-Bright.json
+++ b/bucket/LXGW-Bright.json
@@ -1,0 +1,74 @@
+{
+    "version": "2.152",
+    "description": "An open-source Simplified Chinese font. Combination of LXGW WenKai Lite (霞鹜文楷 Lite) and Ysabeau Office",
+    "homepage": "https://github.com/lxgw/LxgwBright",
+    "license": "OFL-1.1",
+    "url": [
+        "https://raw.githubusercontent.com/lxgw/LxgwBright/main/OTF/LXGWBright-Italic.otf",
+        "https://raw.githubusercontent.com/lxgw/LxgwBright/main/OTF/LXGWBright-Medium.otf",
+        "https://raw.githubusercontent.com/lxgw/LxgwBright/main/OTF/LXGWBright-MediumItalic.otf",
+        "https://raw.githubusercontent.com/lxgw/LxgwBright/main/OTF/LXGWBright-Regular.otf",
+        "https://raw.githubusercontent.com/lxgw/LxgwBright/main/OTF/LXGWBright-SemiLight.otf",
+        "https://raw.githubusercontent.com/lxgw/LxgwBright/main/OTF/LXGWBright-SemiLightItalic.otf"
+    ],
+    "hash": [
+        "a1a87204a22dba9547ab0b29efb61fe708c799c15e957304db18e6e6194f8650",
+        "d09d1f1caed82ede41e065ef3ec51e005b54572a28d61614294793711811aa95",
+        "7b20b2e40b7d417fbd1fceecd4d20e25a5f98657c9fbc17e2cb0165dfd196cf3",
+        "d69ca9733eb3cef70085bb824997b1cf1e42bfeeedb7ee5d6546c3ab2f054ec0",
+        "ae12dc38ec4bef240539158525e7b25f0a609f041346f6c6b50c949012f28db7",
+        "298b28a58d1ad436651899ea65fe946f83d9d5f99fd851af6d09c9fdbb4ff4bf"
+    ],
+    "installer": {
+        "script": [
+            "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
+            "$windows1809BuildNumber = 17763",
+            "$isPerUserFontInstallationSupported = $currentBuildNumber -ge $windows1809BuildNumber",
+            "$isFontInstallationForAllUsers = $global -or !$isPerUserFontInstallationSupported",
+            "if ($isFontInstallationForAllUsers -and !(is_admin)) {",
+            "    error \"Administrator rights are required to install $app.\"",
+            "    exit 1",
+            "}",
+            "$fontInstallDir = if ($isFontInstallationForAllUsers) { \"$env:windir\\Fonts\" } else { \"$env:LOCALAPPDATA\\Microsoft\\Windows\\Fonts\" }",
+            "$registryRoot = if ($isFontInstallationForAllUsers) { \"HKLM\" } else { \"HKCU\" }",
+            "$registryKey = \"${registryRoot}:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\"",
+            "New-Item $fontInstallDir -ItemType Directory -ErrorAction SilentlyContinue | Out-Null",
+            "Get-ChildItem $dir -Filter '*.otf' | ForEach-Object {",
+            "    $value = if ($isFontInstallationForAllUsers) { $_.Name } else { \"$fontInstallDir\\$($_.Name)\" }",
+            "    New-ItemProperty -Path $registryKey -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $value -Force | Out-Null",
+            "    Copy-Item $_.FullName -Destination $fontInstallDir",
+            "}"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
+            "$windows1809BuildNumber = 17763",
+            "$isPerUserFontInstallationSupported = $currentBuildNumber -ge $windows1809BuildNumber",
+            "$isFontInstallationForAllUsers = $global -or !$isPerUserFontInstallationSupported",
+            "if ($isFontInstallationForAllUsers -and !(is_admin)) {",
+            "    error \"Administrator rights are required to uninstall $app.\"",
+            "    exit 1",
+            "}",
+            "$fontInstallDir = if ($isFontInstallationForAllUsers) { \"$env:windir\\Fonts\" } else { \"$env:LOCALAPPDATA\\Microsoft\\Windows\\Fonts\" }",
+            "$registryRoot = if ($isFontInstallationForAllUsers) { \"HKLM\" } else { \"HKCU\" }",
+            "$registryKey = \"${registryRoot}:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\"",
+            "Get-ChildItem $dir -Filter '*.otf' | ForEach-Object {",
+            "    Remove-ItemProperty -Path $registryKey -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Force -ErrorAction SilentlyContinue",
+            "    Remove-Item \"$fontInstallDir\\$($_.Name)\" -Force -ErrorAction SilentlyContinue",
+            "}",
+            "Write-Host \"Font family 'LXGW Bright' has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta"
+        ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": [
+            "https://raw.githubusercontent.com/lxgw/LxgwBright/main/OTF/LXGWBright-Italic.otf",
+            "https://raw.githubusercontent.com/lxgw/LxgwBright/main/OTF/LXGWBright-Medium.otf",
+            "https://raw.githubusercontent.com/lxgw/LxgwBright/main/OTF/LXGWBright-MediumItalic.otf",
+            "https://raw.githubusercontent.com/lxgw/LxgwBright/main/OTF/LXGWBright-Regular.otf",
+            "https://raw.githubusercontent.com/lxgw/LxgwBright/main/OTF/LXGWBright-SemiLight.otf",
+            "https://raw.githubusercontent.com/lxgw/LxgwBright/main/OTF/LXGWBright-SemiLightItalic.otf"
+        ]
+    }
+}


### PR DESCRIPTION
* closes #184

* **[LXGW Bright](https://github.com/lxgw/LxgwBright)** is an open-source Chinese font. The font is a combination of **LXGW WenKai** Lite/TC (霞鹜文楷 Lite/TC) and **Ysabeau Office**.

**NOTES**:
* **Naming** of the packages: I named the package as `LXGW-Bright` because the app name (in this case, font name) is `LXGW Bright`. This Follows the convention of *Main* and *Extras* buckets.
* Downloading **independent OTF** files (instead of the archive of whole repo in [releases page](https://github.com/lxgw/LxgwBright/releases)) to avoid **space bloat**.
I think this is fine because the developer will change the version number **every time** when one of the font file updates. See [file history](https://github.com/lxgw/LxgwBright/commits/main/OTF/LXGWBright-Italic.otf) and [release tags](https://github.com/lxgw/LxgwBright/tags) for examples.

![](https://user-images.githubusercontent.com/69144188/177772655-0c3e9c3f-d83d-465d-a29f-93eb66f2c879.png)
![](https://raw.githubusercontent.com/lxgw/LxgwBright/main/images/preview-2.png)