### PR TITLE
(chore): remove andika-compact's autoupdate settings

### DIFF
--- a/bucket/andika-compact.json
+++ b/bucket/andika-compact.json
@@ -1,5 +1,6 @@
 {
     "version": "5.000",
+    "description": "A sans-serif font family designed and optimized especially for literacy use (compact variant)",
     "license": "SIL OFL 1.1",
     "homepage": "https://software.sil.org/andika/",
     "url": "https://software.sil.org/downloads/r/andika/AndikaCompact-5.000.zip",

--- a/bucket/andika-compact.json
+++ b/bucket/andika-compact.json
@@ -4,13 +4,6 @@
     "homepage": "https://software.sil.org/andika/",
     "url": "https://software.sil.org/downloads/r/andika/AndikaCompact-5.000.zip",
     "hash": "047d7abc6a12abf83fe0e62177e835434392c3c6d79e46433bc610fda05e0331",
-    "checkver": {
-        "url": "https://software.sil.org/andika/download/",
-        "regex": "Andika ([\\d.]+) Developer"
-    },
-    "autoupdate": {
-        "url": "https://software.sil.org/downloads/r/andika/AndikaCompact-$version.zip"
-    },
     "pre_install": [
         "Move-Item $dir\\AndikaCompact-$version\\* $dir",
         "Remove-Item $dir\\AndikaCompact-$version"

--- a/bucket/andika-new-basic.json
+++ b/bucket/andika-new-basic.json
@@ -1,5 +1,6 @@
 {
     "version": "5.500",
+    "description": "A sans-serif font family designed and optimized especially for literacy use (basic character set)",
     "license": "SIL OFL 1.1",
     "homepage": "https://software.sil.org/andika/",
     "url": "https://software.sil.org/downloads/r/andika/AndikaNewBasic-5.500.zip",

--- a/bucket/andika.json
+++ b/bucket/andika.json
@@ -1,5 +1,6 @@
 {
     "version": "6.101",
+    "description": "A sans-serif font family designed and optimized especially for literacy use (complete character set)",
     "license": "SIL OFL 1.1",
     "homepage": "https://software.sil.org/andika/",
     "url": "https://software.sil.org/downloads/r/andika/Andika-6.101.zip",


### PR DESCRIPTION
It seems that the compact variant of andika font no longer have any update.