### PR TITLE
Soukou-Mincho: Fix url

### DIFF
--- a/bucket/Soukou-Mincho.json
+++ b/bucket/Soukou-Mincho.json
@@ -4,9 +4,8 @@
     "description": "Japanese and Traditional Chinese font with sharp penstrokes. The name 'soukou' means armor.",
     "homepage": "http://flopdesign.com/blog/font/5228/",
     "license": "OFL-1.1",
-    "url": "https://fontmeme.com/fonts/download/222487/soukou-mincho.zip",
-    "hash": "9f81ce2891875c1f5353853f26ab6b1027470e154fb7b88dc52ce29b686e0897",
-    "extract_dir": "SoukouMincho-Font",
+    "url": "https://raw.githubusercontent.com/wordshub/free-font/52955adfea1c7092e1f91a445f285f413fbdfd07/assets/font/%E6%97%A5%E6%96%87/%E8%A3%85%E7%94%B2%E6%98%8E%E6%9C%9D%E4%BD%93.ttf#/SoukouMincho.ttf",
+    "hash": "82c7d5fe924966c231adb4275d86ef0176390e755ccaaca9b3f3407516229657",
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",


### PR DESCRIPTION
Follow up #203 

It seems that https://fontmeme.com/fonts/download/222487/soukou-mincho.zip cannot be accessed by scoop install command, so I change the download link to https://github.com/wordshub/free-font/blob/52955adfea1c7092e1f91a445f285f413fbdfd07/assets/font/日文/装甲明朝体.ttf

![scoop-install-failed](https://user-images.githubusercontent.com/16042676/202844839-357c0f74-7cba-4a7d-910a-6b792cefa3f7.png)
