### PR TITLE
Plus-Jakarta-Sans: Add version 2.6

### DIFF
--- a/bucket/Plus-Jakarta-Sans.json
+++ b/bucket/Plus-Jakarta-Sans.json
@@ -1,0 +1,73 @@
+{
+    "version": "2.6",
+    "description": "+Jakarta Sans is a open-source fonts. Designed for Jakarta \"City of collaboration\" program in 2020.",
+    "homepage": "https://github.com/tokotype/PlusJakartaSans",
+    "license": "OFL-1.1",
+    "url": "https://github.com/tokotype/PlusJakartaSans/releases/download/2.6/PlusJakartaSans-2.6.zip",
+    "hash": "f1d21a6c99a5e7744574162dafc56e5c0895507fd9250ae04acbb1027733bee3",
+    "extract_dir": "PlusJakartaSans-2.6/static",
+    "installer": {
+        "script": [
+            "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
+            "$windows11Version22H2BuildNumber = 22621",
+            "$doesPerUserFontInstallationHaveIssue = $currentBuildNumber -ge $windows11Version22H2BuildNumber",
+            "if ($doesPerUserFontInstallationHaveIssue -and !$global) {",
+            "    scoop uninstall $app",
+            "    Write-Host \"\"",
+            "    Write-Host \"Currently, on Windows 11 Version 22H2 (OS Build 22621) or later,\" -Foreground DarkRed",
+            "    Write-Host \"Font installation only works when installing font for all users.\" -Foreground DarkRed",
+            "    Write-Host \"\"",
+            "    Write-Host \"Please use following commands to install '$app' Font for all users.\" -Foreground DarkRed",
+            "    Write-Host \"\"",
+            "    Write-Host \"        scoop install sudo\"",
+            "    Write-Host \"        sudo scoop install -g $app\"",
+            "    Write-Host \"\"",
+            "    Write-Host \"See https://github.com/matthewjberger/scoop-nerd-fonts/issues/198 for more details.\" -Foreground Magenta",
+            "    exit 1",
+            "}",
+            "$windows10Version1809BuildNumber = 17763",
+            "$isPerUserFontInstallationSupported = $currentBuildNumber -ge $windows10Version1809BuildNumber",
+            "if (!$isPerUserFontInstallationSupported -and !$global) {",
+            "    scoop uninstall $app",
+            "    Write-Host \"\"",
+            "    Write-Host \"For Windows version before Windows 10 Version 1809 (OS Build 17763),\" -Foreground DarkRed",
+            "    Write-Host \"Font can only be installed for all users.\" -Foreground DarkRed",
+            "    Write-Host \"\"",
+            "    Write-Host \"Please use following commands to install '$app' Font for all users.\" -Foreground DarkRed",
+            "    Write-Host \"\"",
+            "    Write-Host \"        scoop install sudo\"",
+            "    Write-Host \"        sudo scoop install -g $app\"",
+            "    Write-Host \"\"",
+            "    exit 1",
+            "}",
+            "$fontInstallDir = if ($global) { \"$env:windir\\Fonts\" } else { \"$env:LOCALAPPDATA\\Microsoft\\Windows\\Fonts\" }",
+            "$registryRoot = if ($global) { \"HKLM\" } else { \"HKCU\" }",
+            "$registryKey = \"${registryRoot}:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\"",
+            "New-Item $fontInstallDir -ItemType Directory -ErrorAction SilentlyContinue | Out-Null",
+            "Get-ChildItem $dir -Filter '*.ttf' | ForEach-Object {",
+            "    $value = if ($isFontInstallationForAllUsers) { $_.Name } else { \"$fontInstallDir\\$($_.Name)\" }",
+            "    New-ItemProperty -Path $registryKey -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $value -Force | Out-Null",
+            "    Copy-Item $_.FullName -Destination $fontInstallDir",
+            "}"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "$fontInstallDir = if ($global) { \"$env:windir\\Fonts\" } else { \"$env:LOCALAPPDATA\\Microsoft\\Windows\\Fonts\" }",
+            "$registryRoot = if ($global) { \"HKLM\" } else { \"HKCU\" }",
+            "$registryKey = \"${registryRoot}:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\"",
+            "Get-ChildItem $dir -Filter '*.ttf' | ForEach-Object {",
+            "    Remove-ItemProperty -Path $registryKey -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Force -ErrorAction SilentlyContinue",
+            "    Remove-Item \"$fontInstallDir\\$($_.Name)\" -Force -ErrorAction SilentlyContinue",
+            "}",
+            "if ($cmd -eq \"uninstall\") {",
+            "    Write-Host \"Font 'Plus Jakarta Sans' has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
+            "}"
+        ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/tokotype/PlusJakartaSans/releases/download/$version/PlusJakartaSans-$version.zip",
+        "extract_dir": "PlusJakartaSans-$version/static"
+    }
+}


### PR DESCRIPTION
 [+Jakarta Sans](https://github.com/tokotype/PlusJakartaSans) is a open-source fonts. Designed for Jakarta "City of collaboration" program in 2020.
 
 Closes #197

![](https://raw.githubusercontent.com/tokotype/PlusJakartaSans/master/documentation/img/plusjakartasans.png)

![](https://raw.githubusercontent.com/tokotype/PlusJakartaSans/master/documentation/img/plusjakartasans-alt.gif)