### PR TITLE
(chore): add descriptions to default nerd font manifests

### DIFF
--- a/bin/generate-manifests.ps1
+++ b/bin/generate-manifests.ps1
@@ -25,20 +25,24 @@ function Export-FontManifest {
         [switch]$OverwriteExisting
     )
 
+    $description = "Nerd Fonts patched '$Name' Font family."
+    if ($IsMono) {
+        $description += " (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)"
+    } else {
+        $description += " (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)"
+    }
+
     $fullName = if ($IsMono) { "$Name-NF-Mono" } else { "$Name-NF" }
     $path = "$PSScriptRoot\..\bucket\$fullName.json"
     $filter = if ($IsMono) { "'*Mono Windows Compatible.*'" } else { "'*Complete Windows Compatible.*'" }
 
     $templateData = [ordered]@{
         "version"     = "0.0"
-        "license"     = "MIT"
+        "description" = $description
         "homepage"    = "https://github.com/ryanoasis/nerd-fonts"
+        "license"     = "MIT"
         "url"         = " "
         "hash"        = " "
-        "checkver"    = "github"
-        "autoupdate"  = @{
-            "url" = "https://github.com/ryanoasis/nerd-fonts/releases/download/v`$version/${Name}.zip"
-        }
         "installer"   = @{
             "script" = @(
                 '$currentBuildNumber = [int] (Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion").CurrentBuildNumber',
@@ -97,6 +101,10 @@ function Export-FontManifest {
                 '    Write-Host "The ''$($app.Replace(''-NF'', ''''))'' Font family has been uninstalled and will not be present after restarting your computer." -Foreground Magenta',
                 '}'
             )
+        }
+        "checkver"    = "github"
+        "autoupdate"  = @{
+            "url" = "https://github.com/ryanoasis/nerd-fonts/releases/download/v`$version/${Name}.zip"
         }
     }
 

--- a/bucket/3270-NF-Mono.json
+++ b/bucket/3270-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched '3270' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/3270.zip",
     "hash": "69ddc77edf739d9b2699b5ccda288531a0f74a21fa92ea6a9e3c45bdb865634c",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/3270.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/3270.zip"
     }
 }

--- a/bucket/3270-NF.json
+++ b/bucket/3270-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched '3270' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/3270.zip",
     "hash": "69ddc77edf739d9b2699b5ccda288531a0f74a21fa92ea6a9e3c45bdb865634c",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/3270.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/3270.zip"
     }
 }

--- a/bucket/Agave-NF-Mono.json
+++ b/bucket/Agave-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'Agave' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/Agave.zip",
     "hash": "186e81e5ea3dd22f56c85b7db572149d8549140bdfb63091dc3174de22a2d0f6",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Agave.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Agave.zip"
     }
 }

--- a/bucket/Agave-NF.json
+++ b/bucket/Agave-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'Agave' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/Agave.zip",
     "hash": "186e81e5ea3dd22f56c85b7db572149d8549140bdfb63091dc3174de22a2d0f6",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Agave.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Agave.zip"
     }
 }

--- a/bucket/AnonymousPro-NF-Mono.json
+++ b/bucket/AnonymousPro-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'AnonymousPro' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/AnonymousPro.zip",
     "hash": "d9180c46c65c1fd9abb4092ab65acd60e1a1cf2556ed90a093725a5e241a4b05",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/AnonymousPro.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/AnonymousPro.zip"
     }
 }

--- a/bucket/AnonymousPro-NF.json
+++ b/bucket/AnonymousPro-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'AnonymousPro' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/AnonymousPro.zip",
     "hash": "d9180c46c65c1fd9abb4092ab65acd60e1a1cf2556ed90a093725a5e241a4b05",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/AnonymousPro.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/AnonymousPro.zip"
     }
 }

--- a/bucket/Arimo-NF-Mono.json
+++ b/bucket/Arimo-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'Arimo' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/Arimo.zip",
     "hash": "38d274f9fd7e0eae3298789877c9cbfa25278b445bd1053e952fe0fb74806d5c",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Arimo.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Arimo.zip"
     }
 }

--- a/bucket/Arimo-NF.json
+++ b/bucket/Arimo-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'Arimo' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/Arimo.zip",
     "hash": "38d274f9fd7e0eae3298789877c9cbfa25278b445bd1053e952fe0fb74806d5c",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Arimo.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Arimo.zip"
     }
 }

--- a/bucket/AurulentSansMono-NF-Mono.json
+++ b/bucket/AurulentSansMono-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'AurulentSansMono' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/AurulentSansMono.zip",
     "hash": "884da5c5eb6f71cdab62772d5f6b9f1c673bdc9763882838fff5eead7207111a",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/AurulentSansMono.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/AurulentSansMono.zip"
     }
 }

--- a/bucket/AurulentSansMono-NF.json
+++ b/bucket/AurulentSansMono-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'AurulentSansMono' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/AurulentSansMono.zip",
     "hash": "884da5c5eb6f71cdab62772d5f6b9f1c673bdc9763882838fff5eead7207111a",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/AurulentSansMono.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/AurulentSansMono.zip"
     }
 }

--- a/bucket/BigBlueTerminal-NF-Mono.json
+++ b/bucket/BigBlueTerminal-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'BigBlueTerminal' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/BigBlueTerminal.zip",
     "hash": "8ec4a687943e4ff277a3423eb99d4827cc7cb405def55f10fcb40a5791e23f5e",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/BigBlueTerminal.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/BigBlueTerminal.zip"
     }
 }

--- a/bucket/BigBlueTerminal-NF.json
+++ b/bucket/BigBlueTerminal-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'BigBlueTerminal' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/BigBlueTerminal.zip",
     "hash": "8ec4a687943e4ff277a3423eb99d4827cc7cb405def55f10fcb40a5791e23f5e",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/BigBlueTerminal.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/BigBlueTerminal.zip"
     }
 }

--- a/bucket/BitstreamVeraSansMono-NF-Mono.json
+++ b/bucket/BitstreamVeraSansMono-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'BitstreamVeraSansMono' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/BitstreamVeraSansMono.zip",
     "hash": "8df122fb2fd4e7375cbe81db761fee18a1f256116aa41d033f36c4f066d6c498",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/BitstreamVeraSansMono.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/BitstreamVeraSansMono.zip"
     }
 }

--- a/bucket/BitstreamVeraSansMono-NF.json
+++ b/bucket/BitstreamVeraSansMono-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'BitstreamVeraSansMono' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/BitstreamVeraSansMono.zip",
     "hash": "8df122fb2fd4e7375cbe81db761fee18a1f256116aa41d033f36c4f066d6c498",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/BitstreamVeraSansMono.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/BitstreamVeraSansMono.zip"
     }
 }

--- a/bucket/CascadiaCode-NF-Mono.json
+++ b/bucket/CascadiaCode-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'CascadiaCode' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/CascadiaCode.zip",
     "hash": "b4f4f20ab6bbf55dd9ae7dd1fadd4ef2c608f38922c401afcce373b36a9b0407",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/CascadiaCode.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -46,7 +43,7 @@
             "$registryRoot = if ($global) { \"HKLM\" } else { \"HKCU\" }",
             "$registryKey = \"${registryRoot}:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\"",
             "New-Item $fontInstallDir -ItemType Directory -ErrorAction SilentlyContinue | Out-Null",
-            "Get-ChildItem $dir -Filter '*Mono Windows Compatible*' | ForEach-Object {",
+            "Get-ChildItem $dir -Filter '*Mono Windows Compatible.*' | ForEach-Object {",
             "    $value = if ($isFontInstallationForAllUsers) { $_.Name } else { \"$fontInstallDir\\$($_.Name)\" }",
             "    New-ItemProperty -Path $registryKey -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $value -Force | Out-Null",
             "    Copy-Item $_.FullName -Destination $fontInstallDir",
@@ -58,7 +55,7 @@
             "$fontInstallDir = if ($global) { \"$env:windir\\Fonts\" } else { \"$env:LOCALAPPDATA\\Microsoft\\Windows\\Fonts\" }",
             "$registryRoot = if ($global) { \"HKLM\" } else { \"HKCU\" }",
             "$registryKey = \"${registryRoot}:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\"",
-            "Get-ChildItem $dir -Filter '*Mono Windows Compatible*' | ForEach-Object {",
+            "Get-ChildItem $dir -Filter '*Mono Windows Compatible.*' | ForEach-Object {",
             "    Remove-ItemProperty -Path $registryKey -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Force -ErrorAction SilentlyContinue",
             "    Remove-Item \"$fontInstallDir\\$($_.Name)\" -Force -ErrorAction SilentlyContinue",
             "}",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/CascadiaCode.zip"
     }
 }

--- a/bucket/CascadiaCode-NF.json
+++ b/bucket/CascadiaCode-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'CascadiaCode' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/CascadiaCode.zip",
     "hash": "b4f4f20ab6bbf55dd9ae7dd1fadd4ef2c608f38922c401afcce373b36a9b0407",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/CascadiaCode.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -46,7 +43,7 @@
             "$registryRoot = if ($global) { \"HKLM\" } else { \"HKCU\" }",
             "$registryKey = \"${registryRoot}:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\"",
             "New-Item $fontInstallDir -ItemType Directory -ErrorAction SilentlyContinue | Out-Null",
-            "Get-ChildItem $dir -Filter '*Complete Windows Compatible*' | ForEach-Object {",
+            "Get-ChildItem $dir -Filter '*Complete Windows Compatible.*' | ForEach-Object {",
             "    $value = if ($isFontInstallationForAllUsers) { $_.Name } else { \"$fontInstallDir\\$($_.Name)\" }",
             "    New-ItemProperty -Path $registryKey -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Value $value -Force | Out-Null",
             "    Copy-Item $_.FullName -Destination $fontInstallDir",
@@ -58,7 +55,7 @@
             "$fontInstallDir = if ($global) { \"$env:windir\\Fonts\" } else { \"$env:LOCALAPPDATA\\Microsoft\\Windows\\Fonts\" }",
             "$registryRoot = if ($global) { \"HKLM\" } else { \"HKCU\" }",
             "$registryKey = \"${registryRoot}:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\"",
-            "Get-ChildItem $dir -Filter '*Complete Windows Compatible*' | ForEach-Object {",
+            "Get-ChildItem $dir -Filter '*Complete Windows Compatible.*' | ForEach-Object {",
             "    Remove-ItemProperty -Path $registryKey -Name $_.Name.Replace($_.Extension, ' (TrueType)') -Force -ErrorAction SilentlyContinue",
             "    Remove-Item \"$fontInstallDir\\$($_.Name)\" -Force -ErrorAction SilentlyContinue",
             "}",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/CascadiaCode.zip"
     }
 }

--- a/bucket/CodeNewRoman-NF-Mono.json
+++ b/bucket/CodeNewRoman-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'CodeNewRoman' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/CodeNewRoman.zip",
     "hash": "df74171025e40588db3e7b79ecfae4de408692cd75f607fd585e5033b285846b",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/CodeNewRoman.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/CodeNewRoman.zip"
     }
 }

--- a/bucket/CodeNewRoman-NF.json
+++ b/bucket/CodeNewRoman-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'CodeNewRoman' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/CodeNewRoman.zip",
     "hash": "df74171025e40588db3e7b79ecfae4de408692cd75f607fd585e5033b285846b",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/CodeNewRoman.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/CodeNewRoman.zip"
     }
 }

--- a/bucket/Cousine-NF-Mono.json
+++ b/bucket/Cousine-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'Cousine' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/Cousine.zip",
     "hash": "840ff6083753975ba328ea24392ad9f3f86187590e9e3617fc3339509f3e55f0",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Cousine.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Cousine.zip"
     }
 }

--- a/bucket/Cousine-NF.json
+++ b/bucket/Cousine-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'Cousine' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/Cousine.zip",
     "hash": "840ff6083753975ba328ea24392ad9f3f86187590e9e3617fc3339509f3e55f0",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Cousine.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Cousine.zip"
     }
 }

--- a/bucket/DaddyTimeMono-NF-Mono.json
+++ b/bucket/DaddyTimeMono-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'DaddyTimeMono' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/DaddyTimeMono.zip",
     "hash": "1898e76cf209d07667f33286d1ed0231cc5dfeb50b151c1a6cc7660fdb6640ef",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/DaddyTimeMono.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/DaddyTimeMono.zip"
     }
 }

--- a/bucket/DaddyTimeMono-NF.json
+++ b/bucket/DaddyTimeMono-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'DaddyTimeMono' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/DaddyTimeMono.zip",
     "hash": "1898e76cf209d07667f33286d1ed0231cc5dfeb50b151c1a6cc7660fdb6640ef",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/DaddyTimeMono.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/DaddyTimeMono.zip"
     }
 }

--- a/bucket/DejaVuSansMono-NF-Mono.json
+++ b/bucket/DejaVuSansMono-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'DejaVuSansMono' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/DejaVuSansMono.zip",
     "hash": "f05ebb194a76f0437bd95f3d21a5b73d6038ec09c8d4dfd6a37b748a9f548442",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/DejaVuSansMono.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/DejaVuSansMono.zip"
     }
 }

--- a/bucket/DejaVuSansMono-NF.json
+++ b/bucket/DejaVuSansMono-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'DejaVuSansMono' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/DejaVuSansMono.zip",
     "hash": "f05ebb194a76f0437bd95f3d21a5b73d6038ec09c8d4dfd6a37b748a9f548442",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/DejaVuSansMono.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/DejaVuSansMono.zip"
     }
 }

--- a/bucket/DroidSansMono-NF-Mono.json
+++ b/bucket/DroidSansMono-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'DroidSansMono' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/DroidSansMono.zip",
     "hash": "b6fef0c6f789d2f317b192588b5d7aab45ab7b237bd163deb4ed18269ad62192",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/DroidSansMono.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/DroidSansMono.zip"
     }
 }

--- a/bucket/DroidSansMono-NF.json
+++ b/bucket/DroidSansMono-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'DroidSansMono' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/DroidSansMono.zip",
     "hash": "b6fef0c6f789d2f317b192588b5d7aab45ab7b237bd163deb4ed18269ad62192",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/DroidSansMono.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/DroidSansMono.zip"
     }
 }

--- a/bucket/FantasqueSansMono-NF-Mono.json
+++ b/bucket/FantasqueSansMono-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'FantasqueSansMono' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/FantasqueSansMono.zip",
     "hash": "9c374c826b4735f43b628e1fe165b39d2d71bf728af668ec8e0b83f15217dce9",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/FantasqueSansMono.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/FantasqueSansMono.zip"
     }
 }

--- a/bucket/FantasqueSansMono-NF.json
+++ b/bucket/FantasqueSansMono-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'FantasqueSansMono' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/FantasqueSansMono.zip",
     "hash": "9c374c826b4735f43b628e1fe165b39d2d71bf728af668ec8e0b83f15217dce9",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/FantasqueSansMono.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/FantasqueSansMono.zip"
     }
 }

--- a/bucket/FiraCode-NF-Mono.json
+++ b/bucket/FiraCode-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'FiraCode' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/FiraCode.zip",
     "hash": "20182e6e7c42cf8ab479d83af3200266261ec9bd4e80cdaceb793ecd56c9a398",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/FiraCode.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/FiraCode.zip"
     }
 }

--- a/bucket/FiraCode-NF.json
+++ b/bucket/FiraCode-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'FiraCode' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/FiraCode.zip",
     "hash": "20182e6e7c42cf8ab479d83af3200266261ec9bd4e80cdaceb793ecd56c9a398",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/FiraCode.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/FiraCode.zip"
     }
 }

--- a/bucket/FiraMono-NF-Mono.json
+++ b/bucket/FiraMono-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'FiraMono' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/FiraMono.zip",
     "hash": "29fff85e0afe0bd723fbd84e6c9587b08fd277cacc516d49bd379faa95612ac3",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/FiraMono.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/FiraMono.zip"
     }
 }

--- a/bucket/FiraMono-NF.json
+++ b/bucket/FiraMono-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'FiraMono' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/FiraMono.zip",
     "hash": "29fff85e0afe0bd723fbd84e6c9587b08fd277cacc516d49bd379faa95612ac3",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/FiraMono.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/FiraMono.zip"
     }
 }

--- a/bucket/Go-Mono-NF-Mono.json
+++ b/bucket/Go-Mono-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'Go-Mono' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/Go-Mono.zip",
     "hash": "aae3e1c8fb30afae212d1e368cefe425e0b44d9293d4bdc9ab609ce112a28c02",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Go-Mono.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Go-Mono.zip"
     }
 }

--- a/bucket/Go-Mono-NF.json
+++ b/bucket/Go-Mono-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'Go-Mono' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/Go-Mono.zip",
     "hash": "aae3e1c8fb30afae212d1e368cefe425e0b44d9293d4bdc9ab609ce112a28c02",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Go-Mono.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Go-Mono.zip"
     }
 }

--- a/bucket/Gohu-NF-Mono.json
+++ b/bucket/Gohu-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'Gohu' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/Gohu.zip",
     "hash": "8797d419f5540f8b15c6bbafb99d50bc372ed703be188ed82ab26540fad062db",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Gohu.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Gohu.zip"
     }
 }

--- a/bucket/Gohu-NF.json
+++ b/bucket/Gohu-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'Gohu' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/Gohu.zip",
     "hash": "8797d419f5540f8b15c6bbafb99d50bc372ed703be188ed82ab26540fad062db",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Gohu.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Gohu.zip"
     }
 }

--- a/bucket/Hack-NF-Mono.json
+++ b/bucket/Hack-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'Hack' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/Hack.zip",
     "hash": "1f031b6d08d51f4830eacd00853dddc7fbd4ae0a05e169f2c13f3037dd3359b3",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Hack.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Hack.zip"
     }
 }

--- a/bucket/Hack-NF.json
+++ b/bucket/Hack-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'Hack' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/Hack.zip",
     "hash": "1f031b6d08d51f4830eacd00853dddc7fbd4ae0a05e169f2c13f3037dd3359b3",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Hack.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Hack.zip"
     }
 }

--- a/bucket/Hasklig-NF-Mono.json
+++ b/bucket/Hasklig-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'Hasklig' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/Hasklig.zip",
     "hash": "1a81fbdcdfc10fc37ce95ef92d65dc91590881c12ee19e2b43371a035d3b5502",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Hasklig.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Hasklig.zip"
     }
 }

--- a/bucket/Hasklig-NF.json
+++ b/bucket/Hasklig-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'Hasklig' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/Hasklig.zip",
     "hash": "1a81fbdcdfc10fc37ce95ef92d65dc91590881c12ee19e2b43371a035d3b5502",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Hasklig.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Hasklig.zip"
     }
 }

--- a/bucket/HeavyData-NF-Mono.json
+++ b/bucket/HeavyData-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'HeavyData' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/HeavyData.zip",
     "hash": "81b6049c38928b82a661977b78ebdd569e89ce2c1bafee66adf2d5627839f58a",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/HeavyData.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/HeavyData.zip"
     }
 }

--- a/bucket/HeavyData-NF.json
+++ b/bucket/HeavyData-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'HeavyData' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/HeavyData.zip",
     "hash": "81b6049c38928b82a661977b78ebdd569e89ce2c1bafee66adf2d5627839f58a",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/HeavyData.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/HeavyData.zip"
     }
 }

--- a/bucket/Hermit-NF-Mono.json
+++ b/bucket/Hermit-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'Hermit' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/Hermit.zip",
     "hash": "54807ed6adb7c5e81468db019b5c2c2a40f211ad9106063f0029564d12331e57",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Hermit.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Hermit.zip"
     }
 }

--- a/bucket/Hermit-NF.json
+++ b/bucket/Hermit-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'Hermit' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/Hermit.zip",
     "hash": "54807ed6adb7c5e81468db019b5c2c2a40f211ad9106063f0029564d12331e57",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Hermit.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Hermit.zip"
     }
 }

--- a/bucket/IBMPlexMono-NF-Mono.json
+++ b/bucket/IBMPlexMono-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'IBMPlexMono' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/IBMPlexMono.zip",
     "hash": "05c76e08627cae7b334e3bcf88c41a263bd7da02680ec6f6987fc51c25cb4d39",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/IBMPlexMono.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/IBMPlexMono.zip"
     }
 }

--- a/bucket/IBMPlexMono-NF.json
+++ b/bucket/IBMPlexMono-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'IBMPlexMono' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/IBMPlexMono.zip",
     "hash": "05c76e08627cae7b334e3bcf88c41a263bd7da02680ec6f6987fc51c25cb4d39",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/IBMPlexMono.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/IBMPlexMono.zip"
     }
 }

--- a/bucket/Inconsolata-NF-Mono.json
+++ b/bucket/Inconsolata-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'Inconsolata' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/Inconsolata.zip",
     "hash": "9ace3503d84521fc1c304b654341b1b4a6e3a704620709915347a6a19b6d56a3",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Inconsolata.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Inconsolata.zip"
     }
 }

--- a/bucket/Inconsolata-NF.json
+++ b/bucket/Inconsolata-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'Inconsolata' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/Inconsolata.zip",
     "hash": "9ace3503d84521fc1c304b654341b1b4a6e3a704620709915347a6a19b6d56a3",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Inconsolata.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Inconsolata.zip"
     }
 }

--- a/bucket/InconsolataGo-NF-Mono.json
+++ b/bucket/InconsolataGo-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'InconsolataGo' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/InconsolataGo.zip",
     "hash": "263cbc5544806784b2c81a8ef0c0cda1c3ade185c5b4deeaf3271535fd5b6bbd",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/InconsolataGo.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/InconsolataGo.zip"
     }
 }

--- a/bucket/InconsolataGo-NF.json
+++ b/bucket/InconsolataGo-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'InconsolataGo' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/InconsolataGo.zip",
     "hash": "263cbc5544806784b2c81a8ef0c0cda1c3ade185c5b4deeaf3271535fd5b6bbd",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/InconsolataGo.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/InconsolataGo.zip"
     }
 }

--- a/bucket/InconsolataLGC-NF-Mono.json
+++ b/bucket/InconsolataLGC-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'InconsolataLGC' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/InconsolataLGC.zip",
     "hash": "93dd6ae83cb6a44930bb8e2c36addef678869864794de05606e1c7f634fdfdc7",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/InconsolataLGC.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/InconsolataLGC.zip"
     }
 }

--- a/bucket/InconsolataLGC-NF.json
+++ b/bucket/InconsolataLGC-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'InconsolataLGC' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/InconsolataLGC.zip",
     "hash": "93dd6ae83cb6a44930bb8e2c36addef678869864794de05606e1c7f634fdfdc7",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/InconsolataLGC.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/InconsolataLGC.zip"
     }
 }

--- a/bucket/Iosevka-NF-Mono.json
+++ b/bucket/Iosevka-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'Iosevka' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/Iosevka.zip",
     "hash": "c9c661d28756abad70bea9339dd3673548737214ebec8e8481c0966cedc56931",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Iosevka.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Iosevka.zip"
     }
 }

--- a/bucket/Iosevka-NF.json
+++ b/bucket/Iosevka-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'Iosevka' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/Iosevka.zip",
     "hash": "c9c661d28756abad70bea9339dd3673548737214ebec8e8481c0966cedc56931",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Iosevka.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Iosevka.zip"
     }
 }

--- a/bucket/JetBrainsMono-NF-Mono.json
+++ b/bucket/JetBrainsMono-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'JetBrainsMono' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/JetBrainsMono.zip",
     "hash": "8b9b6c58081d179ecd50839a6b211dbd24b61e66d87715860129b6138982ee7b",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/JetBrainsMono.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/JetBrainsMono.zip"
     }
 }

--- a/bucket/JetBrainsMono-NF.json
+++ b/bucket/JetBrainsMono-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'JetBrainsMono' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/JetBrainsMono.zip",
     "hash": "8b9b6c58081d179ecd50839a6b211dbd24b61e66d87715860129b6138982ee7b",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/JetBrainsMono.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/JetBrainsMono.zip"
     }
 }

--- a/bucket/Lekton-NF-Mono.json
+++ b/bucket/Lekton-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'Lekton' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/Lekton.zip",
     "hash": "aacdbe805de028e0d28e2b4971c28e7383eaf408eb09053e30fcb1a45b9b4f13",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Lekton.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Lekton.zip"
     }
 }

--- a/bucket/Lekton-NF.json
+++ b/bucket/Lekton-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'Lekton' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/Lekton.zip",
     "hash": "aacdbe805de028e0d28e2b4971c28e7383eaf408eb09053e30fcb1a45b9b4f13",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Lekton.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Lekton.zip"
     }
 }

--- a/bucket/LiberationMono-NF-Mono.json
+++ b/bucket/LiberationMono-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'LiberationMono' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/LiberationMono.zip",
     "hash": "16a492fbc24aeb5e201fa7d21478c8b7629f96b49827fb5369e8b0d8a75c022b",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/LiberationMono.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/LiberationMono.zip"
     }
 }

--- a/bucket/LiberationMono-NF.json
+++ b/bucket/LiberationMono-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'LiberationMono' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/LiberationMono.zip",
     "hash": "16a492fbc24aeb5e201fa7d21478c8b7629f96b49827fb5369e8b0d8a75c022b",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/LiberationMono.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/LiberationMono.zip"
     }
 }

--- a/bucket/Lilex-NF-Mono.json
+++ b/bucket/Lilex-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'Lilex' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/Lilex.zip",
     "hash": "2f03289ed960bfbcd537da003801070e5ab8761ad7f4c70ea1a857670f6ea62c",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Lilex.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Lilex.zip"
     }
 }

--- a/bucket/Lilex-NF.json
+++ b/bucket/Lilex-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'Lilex' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/Lilex.zip",
     "hash": "2f03289ed960bfbcd537da003801070e5ab8761ad7f4c70ea1a857670f6ea62c",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Lilex.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Lilex.zip"
     }
 }

--- a/bucket/MPlus-NF-Mono.json
+++ b/bucket/MPlus-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'MPlus' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/MPlus.zip",
     "hash": "dcbec092ecf13ddf872b5d7af1f1df0081a2eb5492527ae99df4adeb423c39fc",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/MPlus.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/MPlus.zip"
     }
 }

--- a/bucket/MPlus-NF.json
+++ b/bucket/MPlus-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'MPlus' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/MPlus.zip",
     "hash": "dcbec092ecf13ddf872b5d7af1f1df0081a2eb5492527ae99df4adeb423c39fc",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/MPlus.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/MPlus.zip"
     }
 }

--- a/bucket/Meslo-NF-Mono.json
+++ b/bucket/Meslo-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'Meslo' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/Meslo.zip",
     "hash": "a9dc3bb2442d44bfb6a571e808a0a0528977916b5ee21f58e04c10e266684e72",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Meslo.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Meslo.zip"
     }
 }

--- a/bucket/Meslo-NF.json
+++ b/bucket/Meslo-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'Meslo' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/Meslo.zip",
     "hash": "a9dc3bb2442d44bfb6a571e808a0a0528977916b5ee21f58e04c10e266684e72",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Meslo.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Meslo.zip"
     }
 }

--- a/bucket/Monofur-NF-Mono.json
+++ b/bucket/Monofur-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'Monofur' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/Monofur.zip",
     "hash": "d1f3fa0c0a8daeae3e9891f826609bdc0dc917199b2d2cc6fcca302fce57b3d2",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Monofur.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Monofur.zip"
     }
 }

--- a/bucket/Monofur-NF.json
+++ b/bucket/Monofur-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'Monofur' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/Monofur.zip",
     "hash": "d1f3fa0c0a8daeae3e9891f826609bdc0dc917199b2d2cc6fcca302fce57b3d2",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Monofur.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Monofur.zip"
     }
 }

--- a/bucket/Monoid-NF-Mono.json
+++ b/bucket/Monoid-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'Monoid' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/Monoid.zip",
     "hash": "9f8bf836f20279c3c781fd5e365ca6ecc51657a964e88ae814b3d0c5e1405e4d",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Monoid.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Monoid.zip"
     }
 }

--- a/bucket/Monoid-NF.json
+++ b/bucket/Monoid-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'Monoid' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/Monoid.zip",
     "hash": "9f8bf836f20279c3c781fd5e365ca6ecc51657a964e88ae814b3d0c5e1405e4d",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Monoid.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Monoid.zip"
     }
 }

--- a/bucket/Mononoki-NF-Mono.json
+++ b/bucket/Mononoki-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'Mononoki' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/Mononoki.zip",
     "hash": "d6d21469971ac8cf01d5c1e6a34372466d4f67a0db2e79b6fd0b4d9d6b8c9d05",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Mononoki.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Mononoki.zip"
     }
 }

--- a/bucket/Mononoki-NF.json
+++ b/bucket/Mononoki-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'Mononoki' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/Mononoki.zip",
     "hash": "d6d21469971ac8cf01d5c1e6a34372466d4f67a0db2e79b6fd0b4d9d6b8c9d05",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Mononoki.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Mononoki.zip"
     }
 }

--- a/bucket/Noto-NF-Mono.json
+++ b/bucket/Noto-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'Noto' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/Noto.zip",
     "hash": "0f035ac2e509d64c7bb2ca0ddfea47d2a965b45383d395f9e4011a2d2f305ff2",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Noto.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Noto.zip"
     }
 }

--- a/bucket/Noto-NF.json
+++ b/bucket/Noto-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'Noto' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/Noto.zip",
     "hash": "0f035ac2e509d64c7bb2ca0ddfea47d2a965b45383d395f9e4011a2d2f305ff2",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Noto.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Noto.zip"
     }
 }

--- a/bucket/OpenDyslexic-NF-Mono.json
+++ b/bucket/OpenDyslexic-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'OpenDyslexic' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/OpenDyslexic.zip",
     "hash": "dd1541d249d02e1fb863093a917dec0ca699a7b1ef01784a2aba2bf35a05051f",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/OpenDyslexic.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/OpenDyslexic.zip"
     }
 }

--- a/bucket/OpenDyslexic-NF.json
+++ b/bucket/OpenDyslexic-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'OpenDyslexic' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/OpenDyslexic.zip",
     "hash": "dd1541d249d02e1fb863093a917dec0ca699a7b1ef01784a2aba2bf35a05051f",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/OpenDyslexic.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/OpenDyslexic.zip"
     }
 }

--- a/bucket/Overpass-NF-Mono.json
+++ b/bucket/Overpass-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'Overpass' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/Overpass.zip",
     "hash": "c40e71a8369eb1bd8ccfce217074f6b684594c22835290638136a974314ebc4f",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Overpass.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Overpass.zip"
     }
 }

--- a/bucket/Overpass-NF.json
+++ b/bucket/Overpass-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'Overpass' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/Overpass.zip",
     "hash": "c40e71a8369eb1bd8ccfce217074f6b684594c22835290638136a974314ebc4f",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Overpass.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Overpass.zip"
     }
 }

--- a/bucket/ProFont-NF-Mono.json
+++ b/bucket/ProFont-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'ProFont' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/ProFont.zip",
     "hash": "6ca55a1620f7eab6cea96f2dc83b8fb59bc900f4d72ce4bd508411f86c1ebe11",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/ProFont.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/ProFont.zip"
     }
 }

--- a/bucket/ProFont-NF.json
+++ b/bucket/ProFont-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'ProFont' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/ProFont.zip",
     "hash": "6ca55a1620f7eab6cea96f2dc83b8fb59bc900f4d72ce4bd508411f86c1ebe11",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/ProFont.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/ProFont.zip"
     }
 }

--- a/bucket/ProggyClean-NF-Mono.json
+++ b/bucket/ProggyClean-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'ProggyClean' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/ProggyClean.zip",
     "hash": "196a1bc15d8b8f389f2894e76b591db84803942681ca96cc8fd8a1ad2206fa4b",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/ProggyClean.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/ProggyClean.zip"
     }
 }

--- a/bucket/ProggyClean-NF.json
+++ b/bucket/ProggyClean-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'ProggyClean' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/ProggyClean.zip",
     "hash": "196a1bc15d8b8f389f2894e76b591db84803942681ca96cc8fd8a1ad2206fa4b",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/ProggyClean.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/ProggyClean.zip"
     }
 }

--- a/bucket/RobotoMono-NF-Mono.json
+++ b/bucket/RobotoMono-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'RobotoMono' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/RobotoMono.zip",
     "hash": "067326ee4d7e1d7cd576a3020df17f518bbf70f4ec9127403b6235be30fd3abf",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/RobotoMono.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/RobotoMono.zip"
     }
 }

--- a/bucket/RobotoMono-NF.json
+++ b/bucket/RobotoMono-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'RobotoMono' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/RobotoMono.zip",
     "hash": "067326ee4d7e1d7cd576a3020df17f518bbf70f4ec9127403b6235be30fd3abf",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/RobotoMono.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/RobotoMono.zip"
     }
 }

--- a/bucket/ShareTechMono-NF-Mono.json
+++ b/bucket/ShareTechMono-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'ShareTechMono' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/ShareTechMono.zip",
     "hash": "771344294de74dd0b6139bed80dc9e1d8c6a0e4ada3e2fe917aef5c50ff270d4",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/ShareTechMono.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/ShareTechMono.zip"
     }
 }

--- a/bucket/ShareTechMono-NF.json
+++ b/bucket/ShareTechMono-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'ShareTechMono' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/ShareTechMono.zip",
     "hash": "771344294de74dd0b6139bed80dc9e1d8c6a0e4ada3e2fe917aef5c50ff270d4",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/ShareTechMono.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/ShareTechMono.zip"
     }
 }

--- a/bucket/SourceCodePro-NF-Mono.json
+++ b/bucket/SourceCodePro-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'SourceCodePro' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/SourceCodePro.zip",
     "hash": "a736448f04c73bdefefc356c024a5d9250ec086a0621c84179fc44587650c731",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/SourceCodePro.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/SourceCodePro.zip"
     }
 }

--- a/bucket/SourceCodePro-NF.json
+++ b/bucket/SourceCodePro-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'SourceCodePro' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/SourceCodePro.zip",
     "hash": "a736448f04c73bdefefc356c024a5d9250ec086a0621c84179fc44587650c731",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/SourceCodePro.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/SourceCodePro.zip"
     }
 }

--- a/bucket/SpaceMono-NF-Mono.json
+++ b/bucket/SpaceMono-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'SpaceMono' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/SpaceMono.zip",
     "hash": "f7c864da3d4057fce7163181ae1dd85a6175c5e55a12a5410a00e57302cc7aa8",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/SpaceMono.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/SpaceMono.zip"
     }
 }

--- a/bucket/SpaceMono-NF.json
+++ b/bucket/SpaceMono-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'SpaceMono' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/SpaceMono.zip",
     "hash": "f7c864da3d4057fce7163181ae1dd85a6175c5e55a12a5410a00e57302cc7aa8",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/SpaceMono.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/SpaceMono.zip"
     }
 }

--- a/bucket/Terminus-NF-Mono.json
+++ b/bucket/Terminus-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'Terminus' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/Terminus.zip",
     "hash": "37b233e2bb39d8b484815eb4d43857af177c50eb2e625d2626b60f2ea58449e1",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Terminus.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Terminus.zip"
     }
 }

--- a/bucket/Terminus-NF.json
+++ b/bucket/Terminus-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'Terminus' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/Terminus.zip",
     "hash": "37b233e2bb39d8b484815eb4d43857af177c50eb2e625d2626b60f2ea58449e1",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Terminus.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Terminus.zip"
     }
 }

--- a/bucket/Tinos-NF-Mono.json
+++ b/bucket/Tinos-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'Tinos' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/Tinos.zip",
     "hash": "3e353181bd7eadcac29b31dfbac7a87020daa6b0e870e0c9fe3ff4fc6b647792",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Tinos.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Tinos.zip"
     }
 }

--- a/bucket/Tinos-NF.json
+++ b/bucket/Tinos-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'Tinos' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/Tinos.zip",
     "hash": "3e353181bd7eadcac29b31dfbac7a87020daa6b0e870e0c9fe3ff4fc6b647792",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Tinos.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Tinos.zip"
     }
 }

--- a/bucket/Ubuntu-NF-Mono.json
+++ b/bucket/Ubuntu-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'Ubuntu' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/Ubuntu.zip",
     "hash": "02e4372c5c419251ea7337e0a2347eff29c51125d720fb3f5dcbae13970f8741",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Ubuntu.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Ubuntu.zip"
     }
 }

--- a/bucket/Ubuntu-NF.json
+++ b/bucket/Ubuntu-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'Ubuntu' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/Ubuntu.zip",
     "hash": "02e4372c5c419251ea7337e0a2347eff29c51125d720fb3f5dcbae13970f8741",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Ubuntu.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/Ubuntu.zip"
     }
 }

--- a/bucket/UbuntuMono-NF-Mono.json
+++ b/bucket/UbuntuMono-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'UbuntuMono' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/UbuntuMono.zip",
     "hash": "6a5b0cf6ec7c20c93d3854d0ffa1f0944ad18d11b6574d057b401ece63f64c56",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/UbuntuMono.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/UbuntuMono.zip"
     }
 }

--- a/bucket/UbuntuMono-NF.json
+++ b/bucket/UbuntuMono-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'UbuntuMono' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/UbuntuMono.zip",
     "hash": "6a5b0cf6ec7c20c93d3854d0ffa1f0944ad18d11b6574d057b401ece63f64c56",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/UbuntuMono.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/UbuntuMono.zip"
     }
 }

--- a/bucket/VictorMono-NF-Mono.json
+++ b/bucket/VictorMono-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'VictorMono' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/VictorMono.zip",
     "hash": "21261fbd995653d97ec0879808c2b4fe5cd23dadd43ef4254bd10c30267d8658",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/VictorMono.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/VictorMono.zip"
     }
 }

--- a/bucket/VictorMono-NF.json
+++ b/bucket/VictorMono-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'VictorMono' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/VictorMono.zip",
     "hash": "21261fbd995653d97ec0879808c2b4fe5cd23dadd43ef4254bd10c30267d8658",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/VictorMono.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/VictorMono.zip"
     }
 }

--- a/bucket/iA-Writer-NF-Mono.json
+++ b/bucket/iA-Writer-NF-Mono.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'iA-Writer' Font family. (Monospace version, Nerd Fonts Symbol/Icon will be always 1 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/iA-Writer.zip",
     "hash": "3852130a129dc8b5146744015b468f7e4ba29c00c9a9f0b2b61cabc3316b7c9c",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/iA-Writer.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/iA-Writer.zip"
     }
 }

--- a/bucket/iA-Writer-NF.json
+++ b/bucket/iA-Writer-NF.json
@@ -1,13 +1,10 @@
 {
     "version": "2.2.2",
-    "license": "MIT",
+    "description": "Nerd Fonts patched 'iA-Writer' Font family. (Normal version, Nerd Fonts Symbol/Icon could be 1 or 2 cell wide)",
     "homepage": "https://github.com/ryanoasis/nerd-fonts",
+    "license": "MIT",
     "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/iA-Writer.zip",
     "hash": "3852130a129dc8b5146744015b468f7e4ba29c00c9a9f0b2b61cabc3316b7c9c",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/iA-Writer.zip"
-    },
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -66,5 +63,9 @@
             "    Write-Host \"The '$($app.Replace('-NF', ''))' Font family has been uninstalled and will not be present after restarting your computer.\" -Foreground Magenta",
             "}"
         ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanoasis/nerd-fonts/releases/download/v$version/iA-Writer.zip"
     }
 }


### PR DESCRIPTION
Closes #205

- Add descriptions to default nerd font manifests

- I also update the order of fields to match [scoop's convention](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md#for-scoop-buckets):
      - `version`
      - `description`
      - `homepage`
      - `license`
      - `notes`
      - `depends`
      - `suggest`
      - `url`
      - `hash`
      - `extract_dir`
      - `extract_to`
      - `pre_install`
      - `installer`
      - `post_install`
      - `env_add_path`
      - `env_set`
      - `bin`
      - `shortcuts`
      - `persist`
      - `pre_uninstall`
      - `uninstaller`
      - `post_uninstall`
      - `checkver`
      - `autoupdate`