### PR TITLE
(chore): add tips to generate $fontNames list from nerd-fonts latest release

### DIFF
--- a/bin/generate-manifests.ps1
+++ b/bin/generate-manifests.ps1
@@ -122,6 +122,15 @@ function Export-FontManifest {
     Start-Sleep 1
 }
 
+# Tips: $fontNames list can be generated via the following commands:
+#
+#     scoop install curl
+#     scoop install jq
+#     scoop install busybox-lean
+#
+#     curl --silent https://api.github.com/repos/ryanoasis/nerd-fonts/releases/latest | jq '.assets[].name' | busybox sed 's/^"/    "/; s/.zip"/",/; /FontPatcher/ d; /NerdFontsSymbolsOnly/ d'
+#
+# This is useful to keep $fontNames list up to date with nerd-fonts latest release
 $fontNames = @(
     "3270",
     "Agave",


### PR DESCRIPTION
[nerd-fonts just release a newer version 2.3.0](https://github.com/ryanoasis/nerd-fonts/releases/tag/v2.3.0), and I'm curious if there are new font added in this release.

Eventually, I come up with a one-liner to do that, and I think it's worth to put this command into a comment for the future contributors (including future me 🤣)

P.S. It turns out no new font were added in 2.3.0