### PR TITLE
jf-open-hunnin: Update to version 2.0

### DIFF
--- a/bucket/jf-open-huninn.json
+++ b/bucket/jf-open-huninn.json
@@ -1,11 +1,10 @@
 {
-    "version": "1.1",
+    "version": "2.0",
     "description": "CJK (Chinese-Japanese-Korean) sans-serif font with round curves. The name 'hunnin' means boba(tapioca balls).",
     "homepage": "https://github.com/justfont/open-huninn-font",
     "license": "OFL-1.1",
-    "url": "https://github.com/justfont/open-huninn-font/releases/download/v1.1/jf-openhuninn-1.1.zip",
-    "hash": "1b5a8d0204f5763408609d5e8182455d23a2ebc7450730aed19cc13c619bca37",
-    "extract_dir": "jf-openhuninn-1.1",
+    "url": "https://github.com/justfont/open-huninn-font/releases/download/v2.0/jf-openhuninn-2.0.ttf",
+    "hash": "86cb149f056f52e11fd6ce7fecfe33e3914415a44d0f56275aabaab90f4a21ae",
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",
@@ -67,7 +66,6 @@
     },
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/justfont/open-huninn-font/releases/download/v$version/jf-openhuninn-$version.zip",
-        "extract_dir": "jf-openhuninn-$version"
+        "url": "https://github.com/justfont/open-huninn-font/releases/download/v$version/jf-openhuninn-$version.ttf"
     }
 }


### PR DESCRIPTION
As the release asset is now a single .ttf file instead of a .zip file, this PR updates `autoupdate` and removes `extract_dir` accordingly.