### PR TITLE
Victor-Mono: Change download url to fix hash issues

### DIFF
--- a/bucket/Victor-Mono.json
+++ b/bucket/Victor-Mono.json
@@ -3,8 +3,8 @@
     "description": "Programming font with optional semi-connected cursive italics, symbol ligatures and Latin, Cyrillic and Greek characters",
     "homepage": "https://rubjo.github.io/victor-mono",
     "license": "MIT",
-    "url": "https://rubjo.github.io/victor-mono/VictorMonoAll.zip",
-    "hash": "bf69bd719fb00ccb503e7574df07dccc257f1f3f8417526b642112f5d7aa3f02",
+    "url": "https://raw.githubusercontent.com/rubjo/victor-mono/v1.5.6/public/VictorMonoAll.zip",
+    "hash": "eab377ad3bcc7a202697c024ebb8c8728f99789c4f093d358f3d202052cc9496",
     "extract_dir": "OTF",
     "installer": {
         "script": [
@@ -90,6 +90,6 @@
         "github": "https://github.com/rubjo/victor-mono"
     },
     "autoupdate": {
-        "url": "https://rubjo.github.io/victor-mono/VictorMonoAll.zip"
+        "url": "https://raw.githubusercontent.com/rubjo/victor-mono/v$version/public/VictorMonoAll.zip"
     }
 }


### PR DESCRIPTION
Resolves #277

This PR changes the download URL from:

https://rubjo.github.io/victor-mono/VictorMonoAll.zip

to:

https://raw.githubusercontent.com/rubjo/victor-mono/v1.5.6/public/VictorMonoAll.zip

to avoid potential `hash check failed` issues.