### PR TITLE
Many: Fix url

### DIFF
--- a/bucket/Bai-Jamjuree.json
+++ b/bucket/Bai-Jamjuree.json
@@ -3,7 +3,20 @@
     "description": "Thai National Font. The name 'Bai Jamjuree' a rain tree's leaf.",
     "homepage": "https://fonts.google.com/specimen/Bai+Jamjuree",
     "license": "OFL-1.1",
-    "url": "https://fonts.google.com/download?family=Bai%20Jamjuree#/fonts.zip",
+    "url": [
+        "https://github.com/google/fonts/raw/main/ofl/baijamjuree/BaiJamjuree-Bold.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/baijamjuree/BaiJamjuree-BoldItalic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/baijamjuree/BaiJamjuree-ExtraLight.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/baijamjuree/BaiJamjuree-ExtraLightItalic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/baijamjuree/BaiJamjuree-Italic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/baijamjuree/BaiJamjuree-Light.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/baijamjuree/BaiJamjuree-LightItalic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/baijamjuree/BaiJamjuree-Medium.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/baijamjuree/BaiJamjuree-MediumItalic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/baijamjuree/BaiJamjuree-Regular.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/baijamjuree/BaiJamjuree-SemiBold.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/baijamjuree/BaiJamjuree-SemiBoldItalic.ttf"
+    ],
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",

--- a/bucket/Chakra-Petch.json
+++ b/bucket/Chakra-Petch.json
@@ -3,7 +3,20 @@
     "description": "Thai National Font. The name 'Chakra Petch' means a crystal disc.",
     "homepage": "https://fonts.google.com/specimen/Chakra+Petch",
     "license": "OFL-1.1",
-    "url": "https://fonts.google.com/download?family=Chakra%20Petch#/fonts.zip",
+    "url": [
+        "https://github.com/google/fonts/raw/main/ofl/chakrapetch/ChakraPetch-Bold.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/chakrapetch/ChakraPetch-BoldItalic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/chakrapetch/ChakraPetch-ExtraLight.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/chakrapetch/ChakraPetch-ExtraLightItalic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/chakrapetch/ChakraPetch-Italic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/chakrapetch/ChakraPetch-Light.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/chakrapetch/ChakraPetch-LightItalic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/chakrapetch/ChakraPetch-Medium.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/chakrapetch/ChakraPetch-MediumItalic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/chakrapetch/ChakraPetch-Regular.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/chakrapetch/ChakraPetch-SemiBold.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/chakrapetch/ChakraPetch-SemiBoldItalic.ttf"
+    ],
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",

--- a/bucket/Charm.json
+++ b/bucket/Charm.json
@@ -3,7 +3,10 @@
     "description": "Thai National Font",
     "homepage": "https://fonts.google.com/specimen/Charm",
     "license": "OFL-1.1",
-    "url": "https://fonts.google.com/download?family=Charm#/fonts.zip",
+    "url": [
+        "https://github.com/google/fonts/raw/main/ofl/charm/Charm-Bold.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/charm/Charm-Regular.ttf"
+    ],
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",

--- a/bucket/Charmonman.json
+++ b/bucket/Charmonman.json
@@ -3,7 +3,10 @@
     "description": "Thai National Font. The name 'Charmonman' means the heart of a rain tree, known in Thailand as a symbolic tree of Chulalongkorn University.",
     "homepage": "https://fonts.google.com/specimen/Charmonman",
     "license": "OFL-1.1",
-    "url": "https://fonts.google.com/download?family=Charmonman#/fonts.zip",
+    "url": [
+        "https://github.com/google/fonts/raw/main/ofl/charmonman/Charmonman-Bold.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/charmonman/Charmonman-Regular.ttf"
+    ],
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",

--- a/bucket/Fahkwang.json
+++ b/bucket/Fahkwang.json
@@ -3,7 +3,20 @@
     "description": "Thai National Font. The name 'Fahkwang' means 'the wide sky'. It has been inspired by headlines in old Thai newspapers.",
     "homepage": "https://fonts.google.com/specimen/Fahkwang",
     "license": "OFL-1.1",
-    "url": "https://fonts.google.com/download?family=Fahkwang#/fonts.zip",
+    "url": [
+        "https://github.com/google/fonts/raw/main/ofl/fahkwang/Fahkwang-Bold.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/fahkwang/Fahkwang-BoldItalic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/fahkwang/Fahkwang-ExtraLight.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/fahkwang/Fahkwang-ExtraLightItalic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/fahkwang/Fahkwang-Italic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/fahkwang/Fahkwang-Light.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/fahkwang/Fahkwang-LightItalic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/fahkwang/Fahkwang-Medium.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/fahkwang/Fahkwang-MediumItalic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/fahkwang/Fahkwang-Regular.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/fahkwang/Fahkwang-SemiBold.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/fahkwang/Fahkwang-SemiBoldItalic.ttf"
+    ],
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",

--- a/bucket/K2D.json
+++ b/bucket/K2D.json
@@ -3,7 +3,24 @@
     "description": "Thai National Font. This font is also called 'K2D July 8', means beginning of Vassa, also known as Buddhist Lent",
     "homepage": "https://fonts.google.com/specimen/K2D",
     "license": "OFL-1.1",
-    "url": "https://fonts.google.com/download?family=K2D#/fonts.zip",
+    "url": [
+        "https://github.com/google/fonts/raw/main/ofl/k2d/K2D-Bold.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/k2d/K2D-BoldItalic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/k2d/K2D-ExtraBold.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/k2d/K2D-ExtraBoldItalic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/k2d/K2D-ExtraLight.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/k2d/K2D-ExtraLightItalic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/k2d/K2D-Italic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/k2d/K2D-Light.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/k2d/K2D-LightItalic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/k2d/K2D-Medium.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/k2d/K2D-MediumItalic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/k2d/K2D-Regular.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/k2d/K2D-SemiBold.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/k2d/K2D-SemiBoldItalic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/k2d/K2D-Thin.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/k2d/K2D-ThinItalic.ttf"
+    ],
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",

--- a/bucket/Kanit.json
+++ b/bucket/Kanit.json
@@ -3,7 +3,26 @@
     "description": "A formal Loopless Thai and Sans Latin design. The name 'Kanit' means mathematics.",
     "homepage": "http://github.com/cadsondemak/kanit",
     "license": "OFL-1.1",
-    "url": "https://fonts.google.com/download?family=Kanit#/fonts.zip",
+    "url": [
+        "https://github.com/cadsondemak/kanit/raw/master/fonts/ttf/Kanit-Black.ttf",
+        "https://github.com/cadsondemak/kanit/raw/master/fonts/ttf/Kanit-BlackItalic.ttf",
+        "https://github.com/cadsondemak/kanit/raw/master/fonts/ttf/Kanit-Bold.ttf",
+        "https://github.com/cadsondemak/kanit/raw/master/fonts/ttf/Kanit-BoldItalic.ttf",
+        "https://github.com/cadsondemak/kanit/raw/master/fonts/ttf/Kanit-ExtraBold.ttf",
+        "https://github.com/cadsondemak/kanit/raw/master/fonts/ttf/Kanit-ExtraBoldItalic.ttf",
+        "https://github.com/cadsondemak/kanit/raw/master/fonts/ttf/Kanit-ExtraLight.ttf",
+        "https://github.com/cadsondemak/kanit/raw/master/fonts/ttf/Kanit-ExtraLightItalic.ttf",
+        "https://github.com/cadsondemak/kanit/raw/master/fonts/ttf/Kanit-Italic.ttf",
+        "https://github.com/cadsondemak/kanit/raw/master/fonts/ttf/Kanit-Light.ttf",
+        "https://github.com/cadsondemak/kanit/raw/master/fonts/ttf/Kanit-LightItalic.ttf",
+        "https://github.com/cadsondemak/kanit/raw/master/fonts/ttf/Kanit-Medium.ttf",
+        "https://github.com/cadsondemak/kanit/raw/master/fonts/ttf/Kanit-MediumItalic.ttf",
+        "https://github.com/cadsondemak/kanit/raw/master/fonts/ttf/Kanit-Regular.ttf",
+        "https://github.com/cadsondemak/kanit/raw/master/fonts/ttf/Kanit-SemiBold.ttf",
+        "https://github.com/cadsondemak/kanit/raw/master/fonts/ttf/Kanit-SemiBoldItalic.ttf",
+        "https://github.com/cadsondemak/kanit/raw/master/fonts/ttf/Kanit-Thin.ttf",
+        "https://github.com/cadsondemak/kanit/raw/master/fonts/ttf/Kanit-ThinItalic.ttf"
+    ],
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",

--- a/bucket/KoHo.json
+++ b/bucket/KoHo.json
@@ -3,7 +3,20 @@
     "description": "Thai National Font",
     "homepage": "https://fonts.google.com/specimen/KoHo",
     "license": "OFL-1.1",
-    "url": "https://fonts.google.com/download?family=KoHo#/fonts.zip",
+    "url": [
+        "https://github.com/google/fonts/raw/main/ofl/koho/KoHo-Bold.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/koho/KoHo-BoldItalic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/koho/KoHo-ExtraLight.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/koho/KoHo-ExtraLightItalic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/koho/KoHo-Italic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/koho/KoHo-Light.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/koho/KoHo-LightItalic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/koho/KoHo-Medium.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/koho/KoHo-MediumItalic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/koho/KoHo-Regular.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/koho/KoHo-SemiBold.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/koho/KoHo-SemiBoldItalic.ttf"
+    ],
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",

--- a/bucket/Kodchasan.json
+++ b/bucket/Kodchasan.json
@@ -3,7 +3,20 @@
     "description": "Thai National Font. The name 'Kodchasan' means an elephant.",
     "homepage": "https://fonts.google.com/specimen/Kodchasan",
     "license": "OFL-1.1",
-    "url": "https://fonts.google.com/download?family=Kodchasan#/fonts.zip",
+    "url": [
+        "https://github.com/google/fonts/raw/main/ofl/kodchasan/Kodchasan-Bold.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/kodchasan/Kodchasan-BoldItalic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/kodchasan/Kodchasan-ExtraLight.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/kodchasan/Kodchasan-ExtraLightItalic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/kodchasan/Kodchasan-Italic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/kodchasan/Kodchasan-Light.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/kodchasan/Kodchasan-LightItalic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/kodchasan/Kodchasan-Medium.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/kodchasan/Kodchasan-MediumItalic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/kodchasan/Kodchasan-Regular.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/kodchasan/Kodchasan-SemiBold.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/kodchasan/Kodchasan-SemiBoldItalic.ttf"
+    ],
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",

--- a/bucket/Krub.json
+++ b/bucket/Krub.json
@@ -3,7 +3,20 @@
     "description": "Thai National Font. The name 'Krub' (sometimes written as 'Khrap') indicates respect or a request.",
     "homepage": "https://fonts.google.com/specimen/Krub",
     "license": "OFL-1.1",
-    "url": "https://fonts.google.com/download?family=Krub#/fonts.zip",
+    "url": [
+        "https://github.com/google/fonts/raw/main/ofl/krub/Krub-Bold.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/krub/Krub-BoldItalic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/krub/Krub-ExtraLight.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/krub/Krub-ExtraLightItalic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/krub/Krub-Italic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/krub/Krub-Light.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/krub/Krub-LightItalic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/krub/Krub-Medium.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/krub/Krub-MediumItalic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/krub/Krub-Regular.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/krub/Krub-SemiBold.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/krub/Krub-SemiBoldItalic.ttf"
+    ],
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",

--- a/bucket/Mali.json
+++ b/bucket/Mali.json
@@ -3,7 +3,20 @@
     "description": "Thai National Font. This is the handwriting of a grade-6 girl named 'Little Jasmine' or 'Mali', a character created by the designer.",
     "homepage": "https://fonts.google.com/specimen/Mali",
     "license": "OFL-1.1",
-    "url": "https://fonts.google.com/download?family=Mali#/fonts.zip",
+    "url": [
+        "https://github.com/google/fonts/raw/main/ofl/mali/Mali-Bold.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/mali/Mali-BoldItalic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/mali/Mali-ExtraLight.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/mali/Mali-ExtraLightItalic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/mali/Mali-Italic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/mali/Mali-Light.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/mali/Mali-LightItalic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/mali/Mali-Medium.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/mali/Mali-MediumItalic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/mali/Mali-Regular.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/mali/Mali-SemiBold.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/mali/Mali-SemiBoldItalic.ttf"
+    ],
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",

--- a/bucket/Mitr.json
+++ b/bucket/Mitr.json
@@ -3,7 +3,14 @@
     "description": "A formal Loopless Thai and Sans Latin design. The name 'Mitr' means friend.",
     "homepage": "http://github.com/cadsondemak/mitr",
     "license": "OFL-1.1",
-    "url": "https://fonts.google.com/download?family=Mitr#/fonts.zip",
+    "url": [
+        "https://github.com/cadsondemak/mitr/raw/master/fonts/Mitr-200.ttf",
+        "https://github.com/cadsondemak/mitr/raw/master/fonts/Mitr-300.ttf",
+        "https://github.com/cadsondemak/mitr/raw/master/fonts/Mitr-400.ttf",
+        "https://github.com/cadsondemak/mitr/raw/master/fonts/Mitr-500.ttf",
+        "https://github.com/cadsondemak/mitr/raw/master/fonts/Mitr-600.ttf",
+        "https://github.com/cadsondemak/mitr/raw/master/fonts/Mitr-700.ttf"
+    ],
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",

--- a/bucket/Niramit.json
+++ b/bucket/Niramit.json
@@ -3,7 +3,20 @@
     "description": "Thai National Font. The name 'Niramit' means being invented by magic.",
     "homepage": "https://fonts.google.com/specimen/Niramit",
     "license": "OFL-1.1",
-    "url": "https://fonts.google.com/download?family=Niramit#/fonts.zip",
+    "url": [
+        "https://github.com/google/fonts/raw/main/ofl/niramit/Niramit-Bold.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/niramit/Niramit-BoldItalic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/niramit/Niramit-ExtraLight.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/niramit/Niramit-ExtraLightItalic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/niramit/Niramit-Italic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/niramit/Niramit-Light.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/niramit/Niramit-LightItalic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/niramit/Niramit-Medium.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/niramit/Niramit-MediumItalic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/niramit/Niramit-Regular.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/niramit/Niramit-SemiBold.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/niramit/Niramit-SemiBoldItalic.ttf"
+    ],
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",

--- a/bucket/Prompt.json
+++ b/bucket/Prompt.json
@@ -3,7 +3,26 @@
     "description": "A loopless Thai and sans Latin typeface",
     "homepage": "https://github.com/cadsondemak/prompt",
     "license": "OFL-1.1",
-    "url": "https://fonts.google.com/download?family=Prompt#/fonts.zip",
+    "url": [
+        "https://github.com/cadsondemak/prompt/raw/master/font/Prompt-Black.ttf",
+        "https://github.com/cadsondemak/prompt/raw/master/font/Prompt-BlackItalic.ttf",
+        "https://github.com/cadsondemak/prompt/raw/master/font/Prompt-Bold.ttf",
+        "https://github.com/cadsondemak/prompt/raw/master/font/Prompt-BoldItalic.ttf",
+        "https://github.com/cadsondemak/prompt/raw/master/font/Prompt-ExtraBold.ttf",
+        "https://github.com/cadsondemak/prompt/raw/master/font/Prompt-ExtraBoldItalic.ttf",
+        "https://github.com/cadsondemak/prompt/raw/master/font/Prompt-ExtraLight.ttf",
+        "https://github.com/cadsondemak/prompt/raw/master/font/Prompt-ExtraLightItalic.ttf",
+        "https://github.com/cadsondemak/prompt/raw/master/font/Prompt-Italic.ttf",
+        "https://github.com/cadsondemak/prompt/raw/master/font/Prompt-Light.ttf",
+        "https://github.com/cadsondemak/prompt/raw/master/font/Prompt-LightItalic.ttf",
+        "https://github.com/cadsondemak/prompt/raw/master/font/Prompt-Medium.ttf",
+        "https://github.com/cadsondemak/prompt/raw/master/font/Prompt-MediumItalic.ttf",
+        "https://github.com/cadsondemak/prompt/raw/master/font/Prompt-Regular.ttf",
+        "https://github.com/cadsondemak/prompt/raw/master/font/Prompt-SemiBold.ttf",
+        "https://github.com/cadsondemak/prompt/raw/master/font/Prompt-SemiBoldItalic.ttf",
+        "https://github.com/cadsondemak/prompt/raw/master/font/Prompt-Thin.ttf",
+        "https://github.com/cadsondemak/prompt/raw/master/font/Prompt-ThinItalic.ttf"
+    ],
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",

--- a/bucket/Raleway.json
+++ b/bucket/Raleway.json
@@ -3,7 +3,26 @@
     "description": "Elegant sans-serif typeface family.",
     "homepage": "https://github.com/impallari/Raleway/",
     "license": "OFL-1.1",
-    "url": "https://fonts.google.com/download?family=Raleway#/fonts.zip",
+    "url": [
+        "https://github.com/impallari/Raleway/raw/master/fonts/v4020/Raleway-v4020-Black.otf",
+        "https://github.com/impallari/Raleway/raw/master/fonts/v4020/Raleway-v4020-BlackItalic.otf",
+        "https://github.com/impallari/Raleway/raw/master/fonts/v4020/Raleway-v4020-Bold.otf",
+        "https://github.com/impallari/Raleway/raw/master/fonts/v4020/Raleway-v4020-BoldItalic.otf",
+        "https://github.com/impallari/Raleway/raw/master/fonts/v4020/Raleway-v4020-ExtraBold.otf",
+        "https://github.com/impallari/Raleway/raw/master/fonts/v4020/Raleway-v4020-ExtraBoldItalic.otf",
+        "https://github.com/impallari/Raleway/raw/master/fonts/v4020/Raleway-v4020-ExtraLight.otf",
+        "https://github.com/impallari/Raleway/raw/master/fonts/v4020/Raleway-v4020-ExtraLightItalic.otf",
+        "https://github.com/impallari/Raleway/raw/master/fonts/v4020/Raleway-v4020-Light.otf",
+        "https://github.com/impallari/Raleway/raw/master/fonts/v4020/Raleway-v4020-LightItalic.otf",
+        "https://github.com/impallari/Raleway/raw/master/fonts/v4020/Raleway-v4020-Medium.otf",
+        "https://github.com/impallari/Raleway/raw/master/fonts/v4020/Raleway-v4020-MediumItalic.otf",
+        "https://github.com/impallari/Raleway/raw/master/fonts/v4020/Raleway-v4020-Regular.otf",
+        "https://github.com/impallari/Raleway/raw/master/fonts/v4020/Raleway-v4020-RegularItalic.otf",
+        "https://github.com/impallari/Raleway/raw/master/fonts/v4020/Raleway-v4020-SemiBold.otf",
+        "https://github.com/impallari/Raleway/raw/master/fonts/v4020/Raleway-v4020-SemiBoldItalic.otf",
+        "https://github.com/impallari/Raleway/raw/master/fonts/v4020/Raleway-v4020-Thin.otf",
+        "https://github.com/impallari/Raleway/raw/master/fonts/v4020/Raleway-v4020-ThinItalic.otf"
+    ],
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",

--- a/bucket/Sarabun.json
+++ b/bucket/Sarabun.json
@@ -3,7 +3,24 @@
     "description": "Thai National Font. The name 'Sarabun' means documentary affairs.",
     "homepage": "https://fonts.google.com/specimen/Sarabun",
     "license": "OFL-1.1",
-    "url": "https://fonts.google.com/download?family=Sarabun#/fonts.zip",
+    "url": [
+        "https://github.com/google/fonts/raw/main/ofl/sarabun/Sarabun-Bold.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/sarabun/Sarabun-BoldItalic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/sarabun/Sarabun-ExtraBold.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/sarabun/Sarabun-ExtraBoldItalic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/sarabun/Sarabun-ExtraLight.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/sarabun/Sarabun-ExtraLightItalic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/sarabun/Sarabun-Italic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/sarabun/Sarabun-Light.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/sarabun/Sarabun-LightItalic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/sarabun/Sarabun-Medium.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/sarabun/Sarabun-MediumItalic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/sarabun/Sarabun-Regular.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/sarabun/Sarabun-SemiBold.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/sarabun/Sarabun-SemiBoldItalic.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/sarabun/Sarabun-Thin.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/sarabun/Sarabun-ThinItalic.ttf"
+    ],
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",

--- a/bucket/Srisakdi.json
+++ b/bucket/Srisakdi.json
@@ -3,7 +3,10 @@
     "description": "Thai National Font. The name 'Srisakdi' means prestige. The Thai scripts are in the 'court style', a style of writing prominent during the Thon Buri Kingdom.",
     "homepage": "https://fonts.google.com/specimen/Srisakdi",
     "license": "OFL-1.1",
-    "url": "https://fonts.google.com/download?family=Srisakdi#/fonts.zip",
+    "url": [
+        "https://github.com/google/fonts/raw/main/ofl/srisakdi/Srisakdi-Bold.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/srisakdi/Srisakdi-Regular.ttf"
+    ],
     "installer": {
         "script": [
             "$currentBuildNumber = [int] (Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").CurrentBuildNumber",


### PR DESCRIPTION
This PR changes the download URL from the Google Fonts site to GitHub, because the original mechanism, downloading through a URL like `https://fonts.google.com/download?family=Raleway#/fonts.zip`, no longer work as excepted.

- Bai-Jamjuree: Fix url
- Chakra-Petch: Fix url
- Charm: Fix url
- Charmonman: Fix url
- Fahkwang: Fix url
- K2D: Fix url
- Kanit: Fix url
- KoHo: Fix url
- Kodchasan: Fix url
- Krub: Fix url
- Mali: Fix url
- Mitr: Fix url
- Niramit: Fix url
- Prompt: Fix url
- Raleway: Fix url
- Sarabun: Fix url
- Srisakdi: Fix url

Resolves #290 