### PR TITLE
(chore): simplify `IPA` license field

### DIFF
--- a/bucket/IPAex-Gothic.json
+++ b/bucket/IPAex-Gothic.json
@@ -2,10 +2,7 @@
     "version": "004.01",
     "description": "Free CJK font maintained by Japanese government agency. It covers a large set of characters.",
     "homepage": "https://moji.or.jp/ipafont/",
-    "license": {
-        "identifier": "Freeware",
-        "url": "https://moji.or.jp/ipafont/license/"
-    },
+    "license": "IPA",
     "url": "https://moji.or.jp/wp-content/ipafont/IPAexfont/ipaexg00401.zip",
     "hash": "4ab6fee94bf6f94b3eeb31be2b73c559f738dc6b336d722d5301b1f3f592f850",
     "extract_dir": "ipaexg00401",

--- a/bucket/IPAex-Mincho.json
+++ b/bucket/IPAex-Mincho.json
@@ -2,10 +2,7 @@
     "version": "004.01",
     "description": "Free CJK font maintained by Japanese government agency. It covers a large set of characters.",
     "homepage": "https://moji.or.jp/ipafont/",
-    "license": {
-        "identifier": "Freeware",
-        "url": "https://moji.or.jp/ipafont/license/"
-    },
+    "license": "IPA",
     "url": "https://moji.or.jp/wp-content/ipafont/IPAexfont/ipaexm00401.zip",
     "hash": "9604c77067396b4d2ab49816b3e18db741a70c8b1d43eb28669ae75cd1ce5237",
     "extract_dir": "ipaexm00401",


### PR DESCRIPTION
The `IPA` license is officially listed on SPDX's website (https://spdx.org/licenses/).
Therefore, we can simplify the license field.