### PR TITLE
Open-Sans: Fix url

### DIFF
--- a/bucket/Open-Sans.json
+++ b/bucket/Open-Sans.json
@@ -4,8 +4,8 @@
     "homepage": "https://fonts.google.com/specimen/Open+Sans",
     "license": "OFL-1.1",
     "url": [
-        "https://github.com/google/fonts/raw/main/ofl/opensans/OpenSans-Italic[wdth,wght].ttf",
-        "https://github.com/google/fonts/raw/main/ofl/opensans/OpenSans[wdth,wght].ttf"
+        "https://github.com/google/fonts/raw/main/ofl/opensans/OpenSans-Italic%5Bwdth,wght%5D.ttf",
+        "https://github.com/google/fonts/raw/main/ofl/opensans/OpenSans%5Bwdth,wght%5D.ttf"
     ],
     "installer": {
         "script": [


### PR DESCRIPTION
An error occurred while trying to install Open-Sans fonts due to a pair of characters in the URL: `[` and `]` are now not understood by github.