### PR TITLE
Update Source-Han-Sans to 2.005

### DIFF
--- a/bucket/Source-Han-Sans-HC.json
+++ b/bucket/Source-Han-Sans-HC.json
@@ -1,10 +1,10 @@
 {
-    "version": "2.004",
+    "version": "2.005",
     "description": "Source Han Sans is a set of OpenType Pan-CJK fonts. (Traditional Chinese Hong Kong variant)",
     "homepage": "https://github.com/adobe-fonts/source-han-sans/",
     "license": "OFL-1.1",
-    "url": "https://github.com/adobe-fonts/source-han-sans/releases/latest/download/SourceHanSansHC.zip",
-    "hash": "551cf3ad1527b3debe2b0efb94133c9ef75c873f75f11b933e6bd6a1f37a8a42",
+    "url": "https://github.com/adobe-fonts/source-han-sans/releases/latest/download/11_SourceHanSansHC.zip",
+    "hash": "b10b5e24bff835f4ac10be68f8383d451f7efc7ffbc1f44c904bbe8db458914e",
     "extract_dir": "OTF/TraditionalChineseHK",
     "installer": {
         "script": [
@@ -91,6 +91,6 @@
         "regex": "Version ([\\d.]+)R"
     },
     "autoupdate": {
-        "url": "https://github.com/adobe-fonts/source-han-sans/releases/latest/download/SourceHanSansHC.zip"
+        "url": "https://github.com/adobe-fonts/source-han-sans/releases/latest/download/11_SourceHanSansHC.zip"
     }
 }

--- a/bucket/Source-Han-Sans-J.json
+++ b/bucket/Source-Han-Sans-J.json
@@ -1,10 +1,10 @@
 {
-    "version": "2.004",
+    "version": "2.005",
     "description": "Source Han Sans is a set of OpenType Pan-CJK fonts. (Japanese variant)",
     "homepage": "https://github.com/adobe-fonts/source-han-sans/",
     "license": "OFL-1.1",
-    "url": "https://github.com/adobe-fonts/source-han-sans/releases/latest/download/SourceHanSansJ.zip",
-    "hash": "747734b49301784fed68440711a106de42714d3a7dbc79064a30bbb0cac3f986",
+    "url": "https://github.com/adobe-fonts/source-han-sans/releases/latest/download/07_SourceHanSansJ.zip",
+    "hash": "c6b77d7aabdee4ff6cc24823e3f1048c41cd5bba9df61ca59b071183ec297195",
     "extract_dir": "OTF/Japanese",
     "installer": {
         "script": [
@@ -91,6 +91,6 @@
         "regex": "Version ([\\d.]+)R"
     },
     "autoupdate": {
-        "url": "https://github.com/adobe-fonts/source-han-sans/releases/latest/download/SourceHanSansJ.zip"
+        "url": "https://github.com/adobe-fonts/source-han-sans/releases/latest/download/07_SourceHanSansJ.zip"
     }
 }

--- a/bucket/Source-Han-Sans-K.json
+++ b/bucket/Source-Han-Sans-K.json
@@ -1,10 +1,10 @@
 {
-    "version": "2.004",
+    "version": "2.005",
     "description": "Source Han Sans is a set of OpenType Pan-CJK fonts. (Korean variant)",
     "homepage": "https://github.com/adobe-fonts/source-han-sans/",
     "license": "OFL-1.1",
-    "url": "https://github.com/adobe-fonts/source-han-sans/releases/latest/download/SourceHanSansK.zip",
-    "hash": "5390443fb4fee71af369858d99d3fb78e67bf661194f91a776fb2b5713ab8f44",
+    "url": "https://github.com/adobe-fonts/source-han-sans/releases/latest/download/08_SourceHanSansK.zip",
+    "hash": "3f43910d3bd7bbbae283b9e05b05b2315a2a71e4880d015625994c6b309e9392",
     "extract_dir": "OTF/Korean",
     "installer": {
         "script": [
@@ -91,6 +91,6 @@
         "regex": "Version ([\\d.]+)R"
     },
     "autoupdate": {
-        "url": "https://github.com/adobe-fonts/source-han-sans/releases/latest/download/SourceHanSansK.zip"
+        "url": "https://github.com/adobe-fonts/source-han-sans/releases/latest/download/08_SourceHanSansK.zip"
     }
 }

--- a/bucket/Source-Han-Sans-SC.json
+++ b/bucket/Source-Han-Sans-SC.json
@@ -1,10 +1,10 @@
 {
-    "version": "2.004",
+    "version": "2.005",
     "description": "Source Han Sans is a set of OpenType Pan-CJK fonts. (Simplified Chinese variant)",
     "homepage": "https://github.com/adobe-fonts/source-han-sans/",
     "license": "OFL-1.1",
-    "url": "https://github.com/adobe-fonts/source-han-sans/releases/latest/download/SourceHanSansSC.zip",
-    "hash": "2105cdb5a73a7d63fdfe8311312ad7f5c4d166e3c369a9cf737a35c90dee13a2",
+    "url": "https://github.com/adobe-fonts/source-han-sans/releases/latest/download/09_SourceHanSansSC.zip",    
+    "hash": "ef7364f7ac2564be1ae9c1d74276de2653fe38b73449070398c4fc0b7e032ff1",
     "extract_dir": "OTF/SimplifiedChinese",
     "installer": {
         "script": [
@@ -91,6 +91,6 @@
         "regex": "Version ([\\d.]+)R"
     },
     "autoupdate": {
-        "url": "https://github.com/adobe-fonts/source-han-sans/releases/latest/download/SourceHanSansSC.zip"
+        "url": "https://github.com/adobe-fonts/source-han-sans/releases/latest/download/09_SourceHanSansSC.zip"
     }
 }

--- a/bucket/Source-Han-Sans-TC.json
+++ b/bucket/Source-Han-Sans-TC.json
@@ -1,10 +1,10 @@
 {
-    "version": "2.004",
+    "version": "2.005",
     "description": "Source Han Sans is a set of OpenType Pan-CJK fonts. (Traditional Chinese Taiwan variant)",
     "homepage": "https://github.com/adobe-fonts/source-han-sans/",
     "license": "OFL-1.1",
-    "url": "https://github.com/adobe-fonts/source-han-sans/releases/latest/download/SourceHanSansTC.zip",
-    "hash": "e075d87d245c4a195e46d0f52fe050efc22e48c8f0f286863f77f03265bb7e9e",
+    "url": "https://github.com/adobe-fonts/source-han-sans/releases/latest/download/10_SourceHanSansTC.zip",
+    "hash": "28058dc7d729560c5fa5c850e7298905cac8de55c1e33cfd5cb13e3d7408989e",
     "extract_dir": "OTF/TraditionalChinese",
     "installer": {
         "script": [
@@ -91,6 +91,6 @@
         "regex": "Version ([\\d.]+)R"
     },
     "autoupdate": {
-        "url": "https://github.com/adobe-fonts/source-han-sans/releases/latest/download/SourceHanSansTC.zip"
+        "url": "https://github.com/adobe-fonts/source-han-sans/releases/latest/download/10_SourceHanSansTC.zip"
     }
 }


### PR DESCRIPTION
Updated to Adobe's 2.005R font.
I think Adobe wants to sort by numbers.
So I changed the "autoupdate".

This is my first pull request,
please forgive me if there are any issues.