### PR TITLE
fix(Source-Han-Sans-SC): resolve 404 download error

### DIFF
--- a/bucket/Source-Han-Sans-SC.json
+++ b/bucket/Source-Han-Sans-SC.json
@@ -1,10 +1,10 @@
 {
-    "version": "2.004",
+    "version": "2.005",
     "description": "Source Han Sans is a set of OpenType Pan-CJK fonts. (Simplified Chinese variant)",
     "homepage": "https://github.com/adobe-fonts/source-han-sans/",
     "license": "OFL-1.1",
-    "url": "https://github.com/adobe-fonts/source-han-sans/releases/latest/download/SourceHanSansSC.zip",
-    "hash": "2105cdb5a73a7d63fdfe8311312ad7f5c4d166e3c369a9cf737a35c90dee13a2",
+    "url": "https://github.com/adobe-fonts/source-han-sans/releases/download/2.005R/09_SourceHanSansSC.zip",
+    "hash": "EF7364F7AC2564BE1AE9C1D74276DE2653FE38B73449070398C4FC0B7E032FF1",
     "extract_dir": "OTF/SimplifiedChinese",
     "installer": {
         "script": [
@@ -91,6 +91,6 @@
         "regex": "Version ([\\d.]+)R"
     },
     "autoupdate": {
-        "url": "https://github.com/adobe-fonts/source-han-sans/releases/latest/download/SourceHanSansSC.zip"
+        "url": "https://github.com/adobe-fonts/source-han-sans/releases/download/$versionR/09_SourceHanSansSC.zip"
     }
 }


### PR DESCRIPTION
- Update URL from generic latest/download to version-specific path
- Bump version to 2.005 with updated hash
- Fix autoupdate URL template for future versions

Verified with:
$ scoop install Source-Han-Sans-SC.json
✓ Download: 90.8 MB [100%]
✓ Hash check: passed
✓ Installation: successful

Closes #323